### PR TITLE
Callable iocsh scripts

### DIFF
--- a/iocsh/Agilent_E3631A.iocsh
+++ b/iocsh/Agilent_E3631A.iocsh
@@ -1,0 +1,22 @@
+# ### Agilent_E3631A.iocsh ###
+
+#- ###################################################
+#- PREFIX         - IOC Prefix
+#- INSTANCE       - Instance Prefix
+#- PORT           - Serial port name
+#- IP             - Location of IP module
+#- ###################################################
+
+
+#- Agilent E3631A triple output power supply
+asynSetOption("$(PORT)", -1, "baud",    "9600")
+asynSetOption("$(PORT)", -1, "bits",    "8")
+asynSetOption("$(PORT)", -1, "stop",    "2")
+asynSetOption("$(PORT)", -1, "parity",  "none")
+asynSetOption("$(PORT)", -1, "clocal",  "Y")
+asynSetOption("$(PORT)", -1, "crtscts", "N")
+
+asynOctetSetInputEos( "$(PORT)", -1, "\r\n")
+asynOctetSetOutputEos("$(PORT)", -1, "\r\n")
+
+dbLoadRecords("$(IP)/ipApp/Db/Agilent_E3631A.db", "P=$(PREFIX),S=$(INSTANCE),PORT=$(PORT)")

--- a/iocsh/Agilent_E3631A.iocsh
+++ b/iocsh/Agilent_E3631A.iocsh
@@ -9,7 +9,7 @@
 
 
 #- Agilent E3631A triple output power supply
-iocshLoad("$(IP)/iocsh/setSerialParams.iocsh", "BAUD=9600, BITS=8, STOP=2, PARITY=none")
+iocshLoad("$(IP)/iocsh/setSerialParams.iocsh", "PORT=$(PORT), BAUD=9600, BITS=8, STOP=2, PARITY=none")
 
 asynOctetSetInputEos( "$(PORT)", -1, "\r\n")
 asynOctetSetOutputEos("$(PORT)", -1, "\r\n")

--- a/iocsh/Agilent_E3631A.iocsh
+++ b/iocsh/Agilent_E3631A.iocsh
@@ -9,12 +9,7 @@
 
 
 #- Agilent E3631A triple output power supply
-asynSetOption("$(PORT)", -1, "baud",    "9600")
-asynSetOption("$(PORT)", -1, "bits",    "8")
-asynSetOption("$(PORT)", -1, "stop",    "2")
-asynSetOption("$(PORT)", -1, "parity",  "none")
-asynSetOption("$(PORT)", -1, "clocal",  "Y")
-asynSetOption("$(PORT)", -1, "crtscts", "N")
+iocshLoad("$(IP)/iocsh/setSerialParams.iocsh", "BAUD=9600, BITS=8, STOP=2, PARITY=none")
 
 asynOctetSetInputEos( "$(PORT)", -1, "\r\n")
 asynOctetSetOutputEos("$(PORT)", -1, "\r\n")

--- a/iocsh/Eurotherm2k.iocsh
+++ b/iocsh/Eurotherm2k.iocsh
@@ -12,12 +12,7 @@
 #-                  Default: 1
 #- ###################################################
 
-asynSetOption("$(PORT)", -1, "baud",    "9600")
-asynSetOption("$(PORT)", -1, "bits",    "7")
-asynSetOption("$(PORT)", -1, "stop",    "1")
-asynSetOption("$(PORT)", -1, "parity",  "even")
-asynSetOption("$(PORT)", -1, "clocal",  "Y")
-asynSetOption("$(PORT)", -1, "crtscts", "N")
+iocshLoad("$(IP)/iocsh/setSerialParams.iocsh", "BAUD=9600, BITS=7, STOP=1, PARITY=even")
 
 asynOctetSetInputEos( "$(PORT)", -1, "")
 asynOctetSetOutputEos("$(PORT)", -1, "")

--- a/iocsh/Eurotherm2k.iocsh
+++ b/iocsh/Eurotherm2k.iocsh
@@ -12,8 +12,6 @@
 #-                  Default: 1
 #- ###################################################
 
-
-#- Oxford ILM202 Cryogen Level Meter
 asynSetOption("$(PORT)", -1, "baud",    "9600")
 asynSetOption("$(PORT)", -1, "bits",    "7")
 asynSetOption("$(PORT)", -1, "stop",    "1")

--- a/iocsh/Eurotherm2k.iocsh
+++ b/iocsh/Eurotherm2k.iocsh
@@ -1,0 +1,27 @@
+# ### Eurotherm2k.iocsh ###
+
+#- ###################################################
+#- PREFIX         - IOC Prefix
+#- INSTANCE       - Instance Prefix
+#- PORT           - Serial port name
+#- IP             - Location of IP module
+#- GAD            - Optional: GAD Value
+#-                  Default: 0
+#-
+#- LAD            - Optional: LAD Value
+#-                  Default: 1
+#- ###################################################
+
+
+#- Oxford ILM202 Cryogen Level Meter
+asynSetOption("$(PORT)", -1, "baud",    "9600")
+asynSetOption("$(PORT)", -1, "bits",    "7")
+asynSetOption("$(PORT)", -1, "stop",    "1")
+asynSetOption("$(PORT)", -1, "parity",  "even")
+asynSetOption("$(PORT)", -1, "clocal",  "Y")
+asynSetOption("$(PORT)", -1, "crtscts", "N")
+
+asynOctetSetInputEos( "$(PORT)", -1, "")
+asynOctetSetOutputEos("$(PORT)", -1, "")
+
+dbLoadRecords("$(IP)/ipApp/Db/Eurotherm2k.db", "P=$(PREFIX),TC=$(INSTANCE),PORT=$(PORT),GAD=$(GAD=0),LAD=$(LAD=1)")

--- a/iocsh/Eurotherm2k.iocsh
+++ b/iocsh/Eurotherm2k.iocsh
@@ -12,7 +12,7 @@
 #-                  Default: 1
 #- ###################################################
 
-iocshLoad("$(IP)/iocsh/setSerialParams.iocsh", "BAUD=9600, BITS=7, STOP=1, PARITY=even")
+iocshLoad("$(IP)/iocsh/setSerialParams.iocsh", "PORT=$(PORT), BAUD=9600, BITS=7, STOP=1, PARITY=even")
 
 asynOctetSetInputEos( "$(PORT)", -1, "")
 asynOctetSetOutputEos("$(PORT)", -1, "")

--- a/iocsh/Heidenhain_ND261.iocsh
+++ b/iocsh/Heidenhain_ND261.iocsh
@@ -1,0 +1,21 @@
+# ### Heidenhain_ND261.iocsh ###
+
+#- ###################################################
+#- PREFIX         - IOC Prefix
+#- INSTANCE       - Instance Prefix
+#- PORT           - Serial port name
+#- IP             - Location of IP module
+#- ###################################################
+
+
+asynSetOption("$(PORT)", -1, "baud",    "9600")
+asynSetOption("$(PORT)", -1, "bits",    "7")
+asynSetOption("$(PORT)", -1, "stop",    "2")
+asynSetOption("$(PORT)", -1, "parity",  "even")
+asynSetOption("$(PORT)", -1, "clocal",  "Y")
+asynSetOption("$(PORT)", -1, "crtscts", "N")
+
+asynOctetSetInputEos( "$(PORT)", -1, "\r")
+asynOctetSetOutputEos("$(PORT)", -1, "")
+
+dbLoadRecords("$(IP)/ipApp/Db/heidND261.db", "P=$(PREFIX),PORT=$(PORT)")

--- a/iocsh/Heidenhain_ND261.iocsh
+++ b/iocsh/Heidenhain_ND261.iocsh
@@ -7,7 +7,7 @@
 #- IP             - Location of IP module
 #- ###################################################
 
-iocshLoad("$(IP)/iocsh/setSerialParams.iocsh", "BAUD=9600, BITS=7, STOP=2, PARITY=even")
+iocshLoad("$(IP)/iocsh/setSerialParams.iocsh", "PORT=$(PORT), BAUD=9600, BITS=7, STOP=2, PARITY=even")
 
 asynOctetSetInputEos( "$(PORT)", -1, "\r")
 asynOctetSetOutputEos("$(PORT)", -1, "")

--- a/iocsh/Heidenhain_ND261.iocsh
+++ b/iocsh/Heidenhain_ND261.iocsh
@@ -7,13 +7,7 @@
 #- IP             - Location of IP module
 #- ###################################################
 
-
-asynSetOption("$(PORT)", -1, "baud",    "9600")
-asynSetOption("$(PORT)", -1, "bits",    "7")
-asynSetOption("$(PORT)", -1, "stop",    "2")
-asynSetOption("$(PORT)", -1, "parity",  "even")
-asynSetOption("$(PORT)", -1, "clocal",  "Y")
-asynSetOption("$(PORT)", -1, "crtscts", "N")
+iocshLoad("$(IP)/iocsh/setSerialParams.iocsh", "BAUD=9600, BITS=7, STOP=2, PARITY=even")
 
 asynOctetSetInputEos( "$(PORT)", -1, "\r")
 asynOctetSetOutputEos("$(PORT)", -1, "")

--- a/iocsh/Keithley_2k_gpib.iocsh
+++ b/iocsh/Keithley_2k_gpib.iocsh
@@ -1,0 +1,17 @@
+# ### Keithley_2k_gpib.iocsh ###
+
+#- ###################################################
+#- PREFIX         - IOC Prefix
+#- INSTANCE       - Instance Prefix
+#- PORT           - gpib port name
+#- ADDR           - gpib address
+#- NUM_CHANNELS   - Number of channels (10, 20, 22)
+#- MODEL          - Keithley model number (2700, 2000)
+#- IP             - Location of IP module
+#- ###################################################
+
+asynOctetSetInputEos("$(PORT)", $(ADDR), "\n")
+asynOctetConnect("$(PORT):$(ADDR)", "$(PORT)", $(ADDR), 1, 80)
+
+dbLoadRecords("$(IP)/ipApp/Db/Keithley2kDMM_mf.db","P=$(PREFIX),Dmm=$(INSTANCE),PORT=$(PORT):$(ADDR)")
+doAfterIocInit("seq &Keithley2kDMM,('P=$(PREFIX), Dmm=$(INSTANCE), channels=$(NUM_CHANNELS), model=$(MODEL)')")

--- a/iocsh/Keithley_2k_serial.iocsh
+++ b/iocsh/Keithley_2k_serial.iocsh
@@ -1,0 +1,26 @@
+# ### Keithley_2k_serial.iocsh ###
+
+#- ###################################################
+#- PREFIX         - IOC Prefix
+#- INSTANCE       - Instance Prefix
+#- PORT           - Serial port name
+#- NUM_CHANNELS   - Number of channels (10, 20, 22)
+#- MODEL          - Keithley model number (2700, 2000)
+#- IP             - Location of IP module
+#- BAUD           - Optional: Baud rate you have set the 
+#-                            Keithley to operate at.
+#-                  Default: 9600
+#- ###################################################
+
+asynSetOption("$(PORT)", -1, "baud",    "$(BAUD=9600)")
+asynSetOption("$(PORT)", -1, "bits",    "8")
+asynSetOption("$(PORT)", -1, "stop",    "1")
+asynSetOption("$(PORT)", -1, "parity",  "none")
+asynSetOption("$(PORT)", -1, "clocal",  "Y")
+asynSetOption("$(PORT)", -1, "crtscts", "N")
+
+asynOctetSetInputEos( "$(PORT)", -1, "\r\n")
+asynOctetSetOutputEos("$(PORT)", -1, "\r")
+
+dbLoadRecords("$(IP)/ipApp/Db/Keithley2kDMM_mf.db","P=$(PREFIX),Dmm=$(INSTANCE),PORT=$(PORT)")
+doAfterIocInit("seq &Keithley2kDMM,('P=$(PREFIX), Dmm=$(INSTANCE), channels=$(NUM_CHANNELS), model=$(MODEL)')")

--- a/iocsh/Keithley_2k_serial.iocsh
+++ b/iocsh/Keithley_2k_serial.iocsh
@@ -12,7 +12,7 @@
 #-                  Default: 9600
 #- ###################################################
 
-iocshLoad("$(IP)/iocsh/setSerialParams.iocsh", "BAUD=$(BAUD), BITS=8, STOP=1, PARITY=none")
+iocshLoad("$(IP)/iocsh/setSerialParams.iocsh", "PORT=$(PORT), BAUD=$(BAUD), BITS=8, STOP=1, PARITY=none")
 
 asynOctetSetInputEos( "$(PORT)", -1, "\r\n")
 asynOctetSetOutputEos("$(PORT)", -1, "\r")

--- a/iocsh/Keithley_2k_serial.iocsh
+++ b/iocsh/Keithley_2k_serial.iocsh
@@ -12,12 +12,7 @@
 #-                  Default: 9600
 #- ###################################################
 
-asynSetOption("$(PORT)", -1, "baud",    "$(BAUD=9600)")
-asynSetOption("$(PORT)", -1, "bits",    "8")
-asynSetOption("$(PORT)", -1, "stop",    "1")
-asynSetOption("$(PORT)", -1, "parity",  "none")
-asynSetOption("$(PORT)", -1, "clocal",  "Y")
-asynSetOption("$(PORT)", -1, "crtscts", "N")
+iocshLoad("$(IP)/iocsh/setSerialParams.iocsh", "BAUD=$(BAUD), BITS=8, STOP=1, PARITY=none")
 
 asynOctetSetInputEos( "$(PORT)", -1, "\r\n")
 asynOctetSetOutputEos("$(PORT)", -1, "\r")

--- a/iocsh/LakeShore_330.iocsh
+++ b/iocsh/LakeShore_330.iocsh
@@ -7,7 +7,7 @@
 #- IP             - Location of IP module
 #- ###################################################
 
-iocshLoad("$(IP)/iocsh/setSerialParams.iocsh", "BAUD=1200, BITS=7, STOP=1, PARITY=odd")
+iocshLoad("$(IP)/iocsh/setSerialParams.iocsh", "PORT=$(PORT), BAUD=1200, BITS=7, STOP=1, PARITY=odd")
 
 asynOctetSetInputEos( "$(PORT)", -1, "\r")
 asynOctetSetOutputEos("$(PORT)", -1, "\n")

--- a/iocsh/LakeShore_330.iocsh
+++ b/iocsh/LakeShore_330.iocsh
@@ -7,12 +7,7 @@
 #- IP             - Location of IP module
 #- ###################################################
 
-asynSetOption("$(PORT)", -1, "baud",    "1200")
-asynSetOption("$(PORT)", -1, "bits",    "7")
-asynSetOption("$(PORT)", -1, "stop",    "1")
-asynSetOption("$(PORT)", -1, "parity",  "odd")
-asynSetOption("$(PORT)", -1, "clocal",  "Y")
-asynSetOption("$(PORT)", -1, "crtscts", "N")
+iocshLoad("$(IP)/iocsh/setSerialParams.iocsh", "BAUD=1200, BITS=7, STOP=1, PARITY=odd")
 
 asynOctetSetInputEos( "$(PORT)", -1, "\r")
 asynOctetSetOutputEos("$(PORT)", -1, "\n")

--- a/iocsh/LakeShore_330.iocsh
+++ b/iocsh/LakeShore_330.iocsh
@@ -1,0 +1,20 @@
+# ### LakeShore_330.iocsh ###
+
+#- ###################################################
+#- PREFIX         - IOC Prefix
+#- INSTANCE       - Instance Prefix
+#- PORT           - Serial port name
+#- IP             - Location of IP module
+#- ###################################################
+
+asynSetOption("$(PORT)", -1, "baud",    "1200")
+asynSetOption("$(PORT)", -1, "bits",    "7")
+asynSetOption("$(PORT)", -1, "stop",    "1")
+asynSetOption("$(PORT)", -1, "parity",  "odd")
+asynSetOption("$(PORT)", -1, "clocal",  "Y")
+asynSetOption("$(PORT)", -1, "crtscts", "N")
+
+asynOctetSetInputEos( "$(PORT)", -1, "\r")
+asynOctetSetOutputEos("$(PORT)", -1, "\n")
+
+dbLoadRecords("$(IP)/ipApp/Db/LakeShore330.db", "P=$(PREFIX),Q=$(INSTANCE),PORT=$(PORT)")

--- a/iocsh/LakeShore_340.iocsh
+++ b/iocsh/LakeShore_340.iocsh
@@ -7,12 +7,7 @@
 #- IP             - Location of IP module
 #- ###################################################
 
-asynSetOption("$(PORT)", -1, "baud",    "9600")
-asynSetOption("$(PORT)", -1, "bits",    "8")
-asynSetOption("$(PORT)", -1, "stop",    "1")
-asynSetOption("$(PORT)", -1, "parity",  "none")
-asynSetOption("$(PORT)", -1, "clocal",  "Y")
-asynSetOption("$(PORT)", -1, "crtscts", "N")
+iocshLoad("$(IP)/iocsh/setSerialParams.iocsh", "BAUD=9600, BITS=8, STOP=1, PARITY=none")
 
 asynOctetSetInputEos( "$(PORT)", -1, "\r")
 asynOctetSetOutputEos("$(PORT)", -1, "\r")

--- a/iocsh/LakeShore_340.iocsh
+++ b/iocsh/LakeShore_340.iocsh
@@ -1,0 +1,20 @@
+# ### LakeShore_340.iocsh ###
+
+#- ###################################################
+#- PREFIX         - IOC Prefix
+#- INSTANCE       - Instance Prefix
+#- PORT           - Serial port name
+#- IP             - Location of IP module
+#- ###################################################
+
+asynSetOption("$(PORT)", -1, "baud",    "9600")
+asynSetOption("$(PORT)", -1, "bits",    "8")
+asynSetOption("$(PORT)", -1, "stop",    "1")
+asynSetOption("$(PORT)", -1, "parity",  "none")
+asynSetOption("$(PORT)", -1, "clocal",  "Y")
+asynSetOption("$(PORT)", -1, "crtscts", "N")
+
+asynOctetSetInputEos( "$(PORT)", -1, "\r")
+asynOctetSetOutputEos("$(PORT)", -1, "\r")
+
+dbLoadRecords("$(IP)/ipApp/Db/LakeShore340.db", "P=$(PREFIX),Q=$(INSTANCE),PORT=$(PORT)")

--- a/iocsh/LakeShore_340.iocsh
+++ b/iocsh/LakeShore_340.iocsh
@@ -7,7 +7,7 @@
 #- IP             - Location of IP module
 #- ###################################################
 
-iocshLoad("$(IP)/iocsh/setSerialParams.iocsh", "BAUD=9600, BITS=8, STOP=1, PARITY=none")
+iocshLoad("$(IP)/iocsh/setSerialParams.iocsh", "PORT=$(PORT), BAUD=9600, BITS=8, STOP=1, PARITY=none")
 
 asynOctetSetInputEos( "$(PORT)", -1, "\r")
 asynOctetSetOutputEos("$(PORT)", -1, "\r")

--- a/iocsh/Newport_LAE500.iocsh
+++ b/iocsh/Newport_LAE500.iocsh
@@ -1,0 +1,22 @@
+# ### Newport_LAE500.iocsh ###
+
+#- ###################################################
+#- PREFIX         - IOC Prefix
+#- INSTANCE       - Instance Prefix
+#- PORT           - Serial port name
+#- IP             - Location of IP module
+#- ###################################################
+
+
+#- Newport LAE500 autocollimator support
+asynSetOption("$(PORT)", -1, "baud",    "9600")
+asynSetOption("$(PORT)", -1, "bits",    "8")
+asynSetOption("$(PORT)", -1, "stop",    "1")
+asynSetOption("$(PORT)", -1, "parity",  "none")
+asynSetOption("$(PORT)", -1, "clocal",  "Y")
+asynSetOption("$(PORT)", -1, "crtscts", "N")
+
+asynOctetSetInputEos( "$(PORT)", -1, "\r")
+asynOctetSetOutputEos("$(PORT)", -1, "\r")
+
+dbLoadRecords("$(IP)/ipApp/Db/Newport_LAE500.db", "P=$(PREFIX),R=$(INSTANCE),PORT=$(PORT)")

--- a/iocsh/Newport_LAE500.iocsh
+++ b/iocsh/Newport_LAE500.iocsh
@@ -7,14 +7,8 @@
 #- IP             - Location of IP module
 #- ###################################################
 
-
 #- Newport LAE500 autocollimator support
-asynSetOption("$(PORT)", -1, "baud",    "9600")
-asynSetOption("$(PORT)", -1, "bits",    "8")
-asynSetOption("$(PORT)", -1, "stop",    "1")
-asynSetOption("$(PORT)", -1, "parity",  "none")
-asynSetOption("$(PORT)", -1, "clocal",  "Y")
-asynSetOption("$(PORT)", -1, "crtscts", "N")
+iocshLoad("$(IP)/iocsh/setSerialParams.iocsh", "BAUD=9600, BITS=8, STOP=1, PARITY=none")
 
 asynOctetSetInputEos( "$(PORT)", -1, "\r")
 asynOctetSetOutputEos("$(PORT)", -1, "\r")

--- a/iocsh/Newport_LAE500.iocsh
+++ b/iocsh/Newport_LAE500.iocsh
@@ -8,7 +8,7 @@
 #- ###################################################
 
 #- Newport LAE500 autocollimator support
-iocshLoad("$(IP)/iocsh/setSerialParams.iocsh", "BAUD=9600, BITS=8, STOP=1, PARITY=none")
+iocshLoad("$(IP)/iocsh/setSerialParams.iocsh", "PORT=$(PORT), BAUD=9600, BITS=8, STOP=1, PARITY=none")
 
 asynOctetSetInputEos( "$(PORT)", -1, "\r")
 asynOctetSetOutputEos("$(PORT)", -1, "\r")

--- a/iocsh/Omega_DP41.iocsh
+++ b/iocsh/Omega_DP41.iocsh
@@ -7,12 +7,7 @@
 #- IP             - Location of IP module
 #- ###################################################
 
-asynSetOption("$(PORT)", -1, "baud",    "9600")
-asynSetOption("$(PORT)", -1, "bits",    "8")
-asynSetOption("$(PORT)", -1, "stop",    "1")
-asynSetOption("$(PORT)", -1, "parity",  "odd")
-asynSetOption("$(PORT)", -1, "clocal",  "Y")
-asynSetOption("$(PORT)", -1, "crtscts", "N")
+iocshLoad("$(IP)/iocsh/setSerialParams.iocsh", "BAUD=9600, BITS=8, STOP=1, PARITY=odd")
 
 asynOctetSetInputEos( "$(PORT)", -1, "\r")
 asynOctetSetOutputEos("$(PORT)", -1, "\r")

--- a/iocsh/Omega_DP41.iocsh
+++ b/iocsh/Omega_DP41.iocsh
@@ -7,7 +7,7 @@
 #- IP             - Location of IP module
 #- ###################################################
 
-iocshLoad("$(IP)/iocsh/setSerialParams.iocsh", "BAUD=9600, BITS=8, STOP=1, PARITY=odd")
+iocshLoad("$(IP)/iocsh/setSerialParams.iocsh", "PORT=$(PORT), BAUD=9600, BITS=8, STOP=1, PARITY=odd")
 
 asynOctetSetInputEos( "$(PORT)", -1, "\r")
 asynOctetSetOutputEos("$(PORT)", -1, "\r")

--- a/iocsh/Omega_DP41.iocsh
+++ b/iocsh/Omega_DP41.iocsh
@@ -1,0 +1,20 @@
+# ### Omega_DP41.iocsh ###
+
+#- ###################################################
+#- PREFIX         - IOC Prefix
+#- INSTANCE       - Instance Prefix
+#- PORT           - Serial port name
+#- IP             - Location of IP module
+#- ###################################################
+
+asynSetOption("$(PORT)", -1, "baud",    "9600")
+asynSetOption("$(PORT)", -1, "bits",    "8")
+asynSetOption("$(PORT)", -1, "stop",    "1")
+asynSetOption("$(PORT)", -1, "parity",  "odd")
+asynSetOption("$(PORT)", -1, "clocal",  "Y")
+asynSetOption("$(PORT)", -1, "crtscts", "N")
+
+asynOctetSetInputEos( "$(PORT)", -1, "\r")
+asynOctetSetOutputEos("$(PORT)", -1, "\r")
+
+dbLoadRecords("$(IP)/ipApp/Db/OmegaDP41.db", "P=$(PREFIX),S=$(INSTANCE),PORT=$(PORT)")

--- a/iocsh/Oxford_ILM202.iocsh
+++ b/iocsh/Oxford_ILM202.iocsh
@@ -8,7 +8,7 @@
 #- ###################################################
 
 #- Oxford ILM202 Cryogen Level Meter
-iocshLoad("$(IP)/iocsh/setSerialParams.iocsh", "BAUD=9600, BITS=8, STOP=1, PARITY=none")
+iocshLoad("$(IP)/iocsh/setSerialParams.iocsh", "PORT=$(PORT), BAUD=9600, BITS=8, STOP=1, PARITY=none")
 
 asynOctetSetInputEos( "$(PORT)", -1, "")
 asynOctetSetOutputEos("$(PORT)", -1, "")

--- a/iocsh/Oxford_ILM202.iocsh
+++ b/iocsh/Oxford_ILM202.iocsh
@@ -1,0 +1,22 @@
+# ### Oxford_ILM202.iocsh ###
+
+#- ###################################################
+#- PREFIX         - IOC Prefix
+#- INSTANCE       - Instance Prefix
+#- PORT           - Serial port name
+#- IP             - Location of IP module
+#- ###################################################
+
+
+#- Oxford ILM202 Cryogen Level Meter
+asynSetOption("$(PORT)", -1, "baud",    "9600")
+asynSetOption("$(PORT)", -1, "bits",    "8")
+asynSetOption("$(PORT)", -1, "stop",    "1")
+asynSetOption("$(PORT)", -1, "parity",  "none")
+asynSetOption("$(PORT)", -1, "clocal",  "Y")
+asynSetOption("$(PORT)", -1, "crtscts", "N")
+
+asynOctetSetInputEos( "$(PORT)", -1, "")
+asynOctetSetOutputEos("$(PORT)", -1, "")
+
+dbLoadRecords("$(IP)/ipApp/Db/Oxford_ILM202.db", "P=$(PREFIX),S=$(INSTANCE),PORT=$(PORT)")

--- a/iocsh/Oxford_ILM202.iocsh
+++ b/iocsh/Oxford_ILM202.iocsh
@@ -7,14 +7,8 @@
 #- IP             - Location of IP module
 #- ###################################################
 
-
 #- Oxford ILM202 Cryogen Level Meter
-asynSetOption("$(PORT)", -1, "baud",    "9600")
-asynSetOption("$(PORT)", -1, "bits",    "8")
-asynSetOption("$(PORT)", -1, "stop",    "1")
-asynSetOption("$(PORT)", -1, "parity",  "none")
-asynSetOption("$(PORT)", -1, "clocal",  "Y")
-asynSetOption("$(PORT)", -1, "crtscts", "N")
+iocshLoad("$(IP)/iocsh/setSerialParams.iocsh", "BAUD=9600, BITS=8, STOP=1, PARITY=none")
 
 asynOctetSetInputEos( "$(PORT)", -1, "")
 asynOctetSetOutputEos("$(PORT)", -1, "")

--- a/iocsh/Oxford_X1k.iocsh
+++ b/iocsh/Oxford_X1k.iocsh
@@ -8,7 +8,7 @@
 #- ###################################################
 
 #- Oxford Cyberstar X1000 Scintillation detector and pulse processing unit
-iocshLoad("$(IP)/iocsh/setSerialParams.iocsh", "BAUD=9600, BITS=8, STOP=1, PARITY=none")
+iocshLoad("$(IP)/iocsh/setSerialParams.iocsh", "PORT=$(PORT), BAUD=9600, BITS=8, STOP=1, PARITY=none")
 
 asynOctetSetInputEos( "$(PORT)", -1, "\n")
 asynOctetSetOutputEos("$(PORT)", -1, "\n")

--- a/iocsh/Oxford_X1k.iocsh
+++ b/iocsh/Oxford_X1k.iocsh
@@ -7,14 +7,8 @@
 #- IP             - Location of IP module
 #- ###################################################
 
-
 #- Oxford Cyberstar X1000 Scintillation detector and pulse processing unit
-asynSetOption("$(PORT)", -1, "baud",    "9600")
-asynSetOption("$(PORT)", -1, "bits",    "8")
-asynSetOption("$(PORT)", -1, "stop",    "1")
-asynSetOption("$(PORT)", -1, "parity",  "none")
-asynSetOption("$(PORT)", -1, "clocal",  "Y")
-asynSetOption("$(PORT)", -1, "crtscts", "N")
+iocshLoad("$(IP)/iocsh/setSerialParams.iocsh", "BAUD=9600, BITS=8, STOP=1, PARITY=none")
 
 asynOctetSetInputEos( "$(PORT)", -1, "\n")
 asynOctetSetOutputEos("$(PORT)", -1, "\n")

--- a/iocsh/Oxford_X1k.iocsh
+++ b/iocsh/Oxford_X1k.iocsh
@@ -1,0 +1,22 @@
+# ### Oxford_X1k.iocsh ###
+
+#- ###################################################
+#- PREFIX         - IOC Prefix
+#- INSTANCE       - Instance Prefix
+#- PORT           - Serial port name
+#- IP             - Location of IP module
+#- ###################################################
+
+
+#- Oxford Cyberstar X1000 Scintillation detector and pulse processing unit
+asynSetOption("$(PORT)", -1, "baud",    "9600")
+asynSetOption("$(PORT)", -1, "bits",    "8")
+asynSetOption("$(PORT)", -1, "stop",    "1")
+asynSetOption("$(PORT)", -1, "parity",  "none")
+asynSetOption("$(PORT)", -1, "clocal",  "Y")
+asynSetOption("$(PORT)", -1, "crtscts", "N")
+
+asynOctetSetInputEos( "$(PORT)", -1, "\n")
+asynOctetSetOutputEos("$(PORT)", -1, "\n")
+
+dbLoadRecords("$(IP)/ipApp/Db/Oxford_X1k.db", "P=$(PREFIX),S=$(INSTANCE),PORT=$(PORT)")

--- a/iocsh/Pelco_CM6700.iocsh
+++ b/iocsh/Pelco_CM6700.iocsh
@@ -1,0 +1,24 @@
+# ### Pelco_CM6700.iocsh ###
+
+#- ###################################################
+#- PREFIX         - IOC Prefix
+#- INSTANCE       - Instance Prefix
+#- PORT           - Serial port name
+#- IP             - Location of IP module
+#- SUB            - Optional: Names substitution file (Pelco_CM6700_names.db)
+#-                            Macros P and R will be set automatically.
+#-                  Default: $(IP)/iocsh/Pelco_CM6700_default.substitutions
+#- ###################################################
+
+asynSetOption("$(PORT)", -1, "baud",    "9600")
+asynSetOption("$(PORT)", -1, "bits",    "8")
+asynSetOption("$(PORT)", -1, "stop",    "1")
+asynSetOption("$(PORT)", -1, "parity",  "odd")
+asynSetOption("$(PORT)", -1, "clocal",  "Y")
+asynSetOption("$(PORT)", -1, "crtscts", "N")
+
+asynOctetSetInputEos( "$(PORT)", -1, "")
+asynOctetSetOutputEos("$(PORT)", -1, "")
+
+dbLoadRecords("$(IP)/ipApp/Db/Pelco_CM6700.db", "P=$(PREFIX),R=$(INSTANCE),PORT=$(PORT)")
+dbLoadTemplate("$(SUB=$(IP)/iocsh/Pelco_CM6700_default.substitutions)", "P=$(PREFIX),R=$(INSTANCE)")

--- a/iocsh/Pelco_CM6700.iocsh
+++ b/iocsh/Pelco_CM6700.iocsh
@@ -10,12 +10,7 @@
 #-                  Default: $(IP)/iocsh/Pelco_CM6700_default.substitutions
 #- ###################################################
 
-asynSetOption("$(PORT)", -1, "baud",    "9600")
-asynSetOption("$(PORT)", -1, "bits",    "8")
-asynSetOption("$(PORT)", -1, "stop",    "1")
-asynSetOption("$(PORT)", -1, "parity",  "odd")
-asynSetOption("$(PORT)", -1, "clocal",  "Y")
-asynSetOption("$(PORT)", -1, "crtscts", "N")
+iocshLoad("$(IP)/iocsh/setSerialParams.iocsh", "BAUD=9600, BITS=8, STOP=1, PARITY=odd")
 
 asynOctetSetInputEos( "$(PORT)", -1, "")
 asynOctetSetOutputEos("$(PORT)", -1, "")

--- a/iocsh/Pelco_CM6700.iocsh
+++ b/iocsh/Pelco_CM6700.iocsh
@@ -10,7 +10,7 @@
 #-                  Default: $(IP)/iocsh/Pelco_CM6700_default.substitutions
 #- ###################################################
 
-iocshLoad("$(IP)/iocsh/setSerialParams.iocsh", "BAUD=9600, BITS=8, STOP=1, PARITY=odd")
+iocshLoad("$(IP)/iocsh/setSerialParams.iocsh", "PORT=$(PORT), BAUD=9600, BITS=8, STOP=1, PARITY=odd")
 
 asynOctetSetInputEos( "$(PORT)", -1, "")
 asynOctetSetOutputEos("$(PORT)", -1, "")

--- a/iocsh/Pelco_CM6700_default.substitutions
+++ b/iocsh/Pelco_CM6700_default.substitutions
@@ -1,0 +1,22 @@
+file "$(IP)/ipApp/Db/Pelco_CM6700_names.db"
+{
+pattern
+{STR}
+{ZRST}
+{ONST}
+{TWST}
+{THST}
+{FRST}
+{FVST}
+{SXST}
+{SVST}
+{EIST}
+{NIST}
+{TEST}
+{ELST}
+{TVST}
+{TTST}
+{FTST}
+{FFST}
+}
+

--- a/iocsh/Queensgate_piezo.iocsh
+++ b/iocsh/Queensgate_piezo.iocsh
@@ -1,0 +1,21 @@
+# ### Queensgate_piezo.iocsh ###
+
+#- ###################################################
+#- PREFIX         - IOC Prefix
+#- PORT           - Serial port name
+#- IP             - Location of IP module
+#- ###################################################
+
+
+# Queensgate piezo driver
+asynSetOption("$(PORT)", -1, "baud",    "9600")
+asynSetOption("$(PORT)", -1, "bits",    "7")
+asynSetOption("$(PORT)", -1, "stop",    "2")
+asynSetOption("$(PORT)", -1, "parity",  "odd")
+asynSetOption("$(PORT)", -1, "clocal",  "Y")
+asynSetOption("$(PORT)", -1, "crtscts", "N")
+
+asynOctetSetInputEos( "$(PORT)", -1, "")
+asynOctetSetOutputEos("$(PORT)", -1, "")
+
+dbLoadRecords("$(IP)/ipApp/Db/pzt.db","P=$(PREFIX),PORT=$(PORT)")

--- a/iocsh/Queensgate_piezo.iocsh
+++ b/iocsh/Queensgate_piezo.iocsh
@@ -7,7 +7,7 @@
 #- ###################################################
 
 # Queensgate piezo driver
-iocshLoad("$(IP)/iocsh/setSerialParams.iocsh", "BAUD=9600, BITS=7, STOP=2, PARITY=odd")
+iocshLoad("$(IP)/iocsh/setSerialParams.iocsh", "PORT=$(PORT), BAUD=9600, BITS=7, STOP=2, PARITY=odd")
 
 asynOctetSetInputEos( "$(PORT)", -1, "")
 asynOctetSetOutputEos("$(PORT)", -1, "")

--- a/iocsh/Queensgate_piezo.iocsh
+++ b/iocsh/Queensgate_piezo.iocsh
@@ -6,14 +6,8 @@
 #- IP             - Location of IP module
 #- ###################################################
 
-
 # Queensgate piezo driver
-asynSetOption("$(PORT)", -1, "baud",    "9600")
-asynSetOption("$(PORT)", -1, "bits",    "7")
-asynSetOption("$(PORT)", -1, "stop",    "2")
-asynSetOption("$(PORT)", -1, "parity",  "odd")
-asynSetOption("$(PORT)", -1, "clocal",  "Y")
-asynSetOption("$(PORT)", -1, "crtscts", "N")
+iocshLoad("$(IP)/iocsh/setSerialParams.iocsh", "BAUD=9600, BITS=7, STOP=2, PARITY=odd")
 
 asynOctetSetInputEos( "$(PORT)", -1, "")
 asynOctetSetOutputEos("$(PORT)", -1, "")

--- a/iocsh/SR_570.iocsh
+++ b/iocsh/SR_570.iocsh
@@ -1,0 +1,22 @@
+# ### SR_570.iocsh ###
+
+#- ###################################################
+#- PREFIX         - IOC Prefix
+#- INSTANCE       - Instance Prefix
+#- PORT           - Serial port name
+#- IP             - Location of IP module
+#- ###################################################
+
+
+#- Stanford Research Systems SR570 Current Preamplifier
+asynSetOption("$(PORT)", -1, "baud",    "9600")
+asynSetOption("$(PORT)", -1, "bits",    "8")
+asynSetOption("$(PORT)", -1, "stop",    "2")
+asynSetOption("$(PORT)", -1, "parity",  "none")
+asynSetOption("$(PORT)", -1, "clocal",  "Y")
+asynSetOption("$(PORT)", -1, "crtscts", "N")
+
+asynOctetSetInputEos( "$(PORT)", -1, "\r")
+asynOctetSetOutputEos("$(PORT)", -1, "\r")
+
+dbLoadRecords("$(IP)/ipApp/Db/SR570.db", "P=$(PREFIX),A=$(INSTANCE),PORT=$(PORT)")

--- a/iocsh/SR_570.iocsh
+++ b/iocsh/SR_570.iocsh
@@ -7,14 +7,8 @@
 #- IP             - Location of IP module
 #- ###################################################
 
-
 #- Stanford Research Systems SR570 Current Preamplifier
-asynSetOption("$(PORT)", -1, "baud",    "9600")
-asynSetOption("$(PORT)", -1, "bits",    "8")
-asynSetOption("$(PORT)", -1, "stop",    "2")
-asynSetOption("$(PORT)", -1, "parity",  "none")
-asynSetOption("$(PORT)", -1, "clocal",  "Y")
-asynSetOption("$(PORT)", -1, "crtscts", "N")
+iocshLoad("$(IP)/iocsh/setSerialParams.iocsh", "BAUD=9600, BITS=8, STOP=2, PARITY=none")
 
 asynOctetSetInputEos( "$(PORT)", -1, "\r")
 asynOctetSetOutputEos("$(PORT)", -1, "\r")

--- a/iocsh/SR_570.iocsh
+++ b/iocsh/SR_570.iocsh
@@ -8,7 +8,7 @@
 #- ###################################################
 
 #- Stanford Research Systems SR570 Current Preamplifier
-iocshLoad("$(IP)/iocsh/setSerialParams.iocsh", "BAUD=9600, BITS=8, STOP=2, PARITY=none")
+iocshLoad("$(IP)/iocsh/setSerialParams.iocsh", "PORT=$(PORT), BAUD=9600, BITS=8, STOP=2, PARITY=none")
 
 asynOctetSetInputEos( "$(PORT)", -1, "\r")
 asynOctetSetOutputEos("$(PORT)", -1, "\r")

--- a/iocsh/SR_830.iocsh
+++ b/iocsh/SR_830.iocsh
@@ -7,12 +7,7 @@
 #- IP             - Location of IP module
 #- ###################################################
 
-asynSetOption("$(PORT)", -1, "baud",    "9600")
-asynSetOption("$(PORT)", -1, "bits",    "8")
-asynSetOption("$(PORT)", -1, "stop",    "1")
-asynSetOption("$(PORT)", -1, "parity",  "none")
-asynSetOption("$(PORT)", -1, "clocal",  "Y")
-asynSetOption("$(PORT)", -1, "crtscts", "N")
+iocshLoad("$(IP)/iocsh/setSerialParams.iocsh", "BAUD=9600, BITS=8, STOP=1, PARITY=none")
 
 asynOctetSetInputEos( "$(PORT)", -1, "\r")
 asynOctetSetOutputEos("$(PORT)", -1, "\r")

--- a/iocsh/SR_830.iocsh
+++ b/iocsh/SR_830.iocsh
@@ -1,0 +1,20 @@
+# ### SR_830.iocsh ###
+
+#- ###################################################
+#- PREFIX         - IOC Prefix
+#- INSTANCE       - Instance Prefix
+#- PORT           - Serial port name
+#- IP             - Location of IP module
+#- ###################################################
+
+asynSetOption("$(PORT)", -1, "baud",    "9600")
+asynSetOption("$(PORT)", -1, "bits",    "8")
+asynSetOption("$(PORT)", -1, "stop",    "1")
+asynSetOption("$(PORT)", -1, "parity",  "none")
+asynSetOption("$(PORT)", -1, "clocal",  "Y")
+asynSetOption("$(PORT)", -1, "crtscts", "N")
+
+asynOctetSetInputEos( "$(PORT)", -1, "\r")
+asynOctetSetOutputEos("$(PORT)", -1, "\r")
+
+dbLoadRecords("$(IP)/ipApp/Db/SR830.vdb", "P=$(PREFIX),N=$(INSTANCE),PORT=$(PORT)")

--- a/iocsh/SR_830.iocsh
+++ b/iocsh/SR_830.iocsh
@@ -7,7 +7,7 @@
 #- IP             - Location of IP module
 #- ###################################################
 
-iocshLoad("$(IP)/iocsh/setSerialParams.iocsh", "BAUD=9600, BITS=8, STOP=1, PARITY=none")
+iocshLoad("$(IP)/iocsh/setSerialParams.iocsh", "PORT=$(PORT), BAUD=9600, BITS=8, STOP=1, PARITY=none")
 
 asynOctetSetInputEos( "$(PORT)", -1, "\r")
 asynOctetSetOutputEos("$(PORT)", -1, "\r")

--- a/iocsh/USdigital_X3.iocsh
+++ b/iocsh/USdigital_X3.iocsh
@@ -7,14 +7,8 @@
 #- IP             - Location of IP module
 #- ###################################################
 
-
 #- US Digital X3 Inclinometer
-asynSetOption("$(PORT)", -1, "baud",    "19200")
-asynSetOption("$(PORT)", -1, "bits",    "8")
-asynSetOption("$(PORT)", -1, "stop",    "1")
-asynSetOption("$(PORT)", -1, "parity",  "none")
-asynSetOption("$(PORT)", -1, "clocal",  "Y")
-asynSetOption("$(PORT)", -1, "crtscts", "N")
+iocshLoad("$(IP)/iocsh/setSerialParams.iocsh", "BAUD=19200, BITS=8, STOP=1, PARITY=none")
 
 asynOctetSetInputEos( "$(PORT)", -1, "")
 asynOctetSetOutputEos("$(PORT)", -1, "")

--- a/iocsh/USdigital_X3.iocsh
+++ b/iocsh/USdigital_X3.iocsh
@@ -1,0 +1,22 @@
+# ### USdigital_X3.iocsh ###
+
+#- ###################################################
+#- PREFIX         - IOC Prefix
+#- INSTANCE       - Instance Prefix
+#- PORT           - Serial port name
+#- IP             - Location of IP module
+#- ###################################################
+
+
+#- US Digital X3 Inclinometer
+asynSetOption("$(PORT)", -1, "baud",    "19200")
+asynSetOption("$(PORT)", -1, "bits",    "8")
+asynSetOption("$(PORT)", -1, "stop",    "1")
+asynSetOption("$(PORT)", -1, "parity",  "none")
+asynSetOption("$(PORT)", -1, "clocal",  "Y")
+asynSetOption("$(PORT)", -1, "crtscts", "N")
+
+asynOctetSetInputEos( "$(PORT)", -1, "")
+asynOctetSetOutputEos("$(PORT)", -1, "")
+
+dbLoadRecords("$(IP)/ipApp/Db/USdigital_X3.vdb", "P=$(PREFIX),S=$(INSTANCE),PORT=$(PORT)")

--- a/iocsh/USdigital_X3.iocsh
+++ b/iocsh/USdigital_X3.iocsh
@@ -8,7 +8,7 @@
 #- ###################################################
 
 #- US Digital X3 Inclinometer
-iocshLoad("$(IP)/iocsh/setSerialParams.iocsh", "BAUD=19200, BITS=8, STOP=1, PARITY=none")
+iocshLoad("$(IP)/iocsh/setSerialParams.iocsh", "PORT=$(PORT), BAUD=19200, BITS=8, STOP=1, PARITY=none")
 
 asynOctetSetInputEos( "$(PORT)", -1, "")
 asynOctetSetOutputEos("$(PORT)", -1, "")

--- a/iocsh/setSerialParams.iocsh
+++ b/iocsh/setSerialParams.iocsh
@@ -1,0 +1,13 @@
+#- ###################################################
+#- BAUD=baudrate, BITS=data bits, STOP=stop bits, 
+#- PARITY=none/odd/even, HANDSHAKE=none/hardware
+#- ###################################################
+
+asynSetOption("$(PORT)", -1, "baud",    "$(BAUD=9600)")
+asynSetOption("$(PORT)", -1, "bits",    "$(BITS=8)")
+asynSetOption("$(PORT)", -1, "stop",    "$(STOP=2")
+asynSetOption("$(PORT)", -1, "parity",  "$(PARITY=none)")
+
+#clocal=Y is software handshaking, clocal=N is hardware handshaking
+iocshRun('asynSetOption("$(PORT)", -1, "clocal",  "$(VALUE_$(HANDSHAKE)=Y)"', "VALUE_hardware=N") 
+asynSetOption("$(PORT)", -1, "crtscts", "N")


### PR DESCRIPTION
Added iocsh scripts for the serial devices that I found being actively used across the APS beamlines. Also added a script to easily set all the serial parameters of an asyn port.
