### PR TITLE
Fix protocol file handling of string input

### DIFF
--- a/ipApp/Db/PHD2000.proto
+++ b/ipApp/Db/PHD2000.proto
@@ -12,7 +12,7 @@ PollPeriod = 500;
 
 getString {
    out "\$1";
-   in  "\n%s\r\n%*[><:/*^]";
+   in  "\n%[ A-Z]\r\n%*[><:/*^]";
 }
 
 setString {


### PR DESCRIPTION
The old protocol file failed when the device returned a string with
spaces at the end. One of the responses to the 'mod' command is 'PUMP
'.

I've checked this change with Mark prior to submitting the pull request.
