### PR TITLE
Resolve build errors due to proto files with base 3.14

### DIFF
--- a/ipApp/Db/Makefile
+++ b/ipApp/Db/Makefile
@@ -32,6 +32,6 @@ include $(TOP)/configure/RULES
 ifeq ($(BASE_3_14),YES)
 # Only needed for 3.14 build rules:
 vpath %.proto $(USR_VPATH) $(GENERIC_SRC_DIRS)
-#vpath %.protocol $(USR_VPATH) $(GENERIC_SRC_DIRS)
+vpath %.protocol $(USR_VPATH) $(GENERIC_SRC_DIRS)
 #vpath %.req $(USR_VPATH) $(GENERIC_SRC_DIRS)
 endif

--- a/ipApp/Db/Makefile
+++ b/ipApp/Db/Makefile
@@ -28,3 +28,10 @@ REQ += $(patsubst ../%, %, $(wildcard ../*.req))
 include $(TOP)/configure/RULES
 #----------------------------------------
 #  ADD RULES AFTER THIS LINE
+
+ifeq ($(BASE_3_14),YES)
+# Only needed for 3.14 build rules:
+vpath %.proto $(USR_VPATH) $(GENERIC_SRC_DIRS)
+#vpath %.protocol $(USR_VPATH) $(GENERIC_SRC_DIRS)
+#vpath %.req $(USR_VPATH) $(GENERIC_SRC_DIRS)
+endif


### PR DESCRIPTION
Similar to what was done in the motor driver modules:

https://github.com/epics-motor/motorAerotech/blob/aaca9411ed75986ec11afc51cc8e89a7d8da3137/aerotechApp/Db/Makefile#L26-L29