### PR TITLE
StreamDevice support for CAEN N8031 power supply

### DIFF
--- a/ipApp/Db/caen_N8031.db
+++ b/ipApp/Db/caen_N8031.db
@@ -1,0 +1,719 @@
+record(fanout, "$(P)$(R)ReadAll") {
+    field(PINI, 1)
+    field(LNK0, "$(P)$(R)ReadVoltages.PROC")
+    field(LNK1, "$(P)$(R)ReadCurrents.PROC")
+    field(LNK2, "$(P)$(R)ReadPowerStates.PROC")
+    field(LNK3, "$(P)$(R)ReadRampUpRates.PROC")
+    field(LNK4, "$(P)$(R)ReadRampDownRates.PROC")
+    field(LNK5, "$(P)$(R)ReadPowerDownModes.PROC")
+    field(LNK6, "$(P)$(R)ReadIMonRanges.PROC")
+}
+record(bo, "$(P)$(R)ReadVoltages") {
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto read_voltages($(P)$(R)) $(PORT)")
+}
+record(bo, "$(P)$(R)ReadCurrents") {
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto read_currents($(P)$(R)) $(PORT)")
+}
+record(bo, "$(P)$(R)ReadPowerStates") {
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto read_power_states($(P)$(R)) $(PORT)")
+}
+record(bo, "$(P)$(R)ReadRampUpRates") {
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto read_ramp_up_rates($(P)$(R)) $(PORT)")
+}
+record(bo, "$(P)$(R)ReadRampDownRates") {
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto read_ramp_down_rates($(P)$(R)) $(PORT)")
+}
+record(bo, "$(P)$(R)ReadPowerDownModes") {
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto read_power_down_modes($(P)$(R)) $(PORT)")
+}
+record(bo, "$(P)$(R)ReadIMonRanges") {
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto read_imon_ranges($(P)$(R)) $(PORT)")
+}
+record(seq, "$(P)$(R)sync_all") {
+    field(PINI, 1)
+    field(DLY0, 1)
+    field(DOL0, 1)
+    field(LNK0, "$(P)$(R)current_sync.PROC")
+    field(DOL1, 1)
+    field(LNK1, "$(P)$(R)voltage_sync.PROC")
+    field(DOL2, 1)
+    field(LNK2, "$(P)$(R)power_sync.PROC")
+    field(DOL3, 1)
+    field(LNK3, "$(P)$(R)ramp_up_sync.PROC")
+    field(DOL4, 1)
+    field(LNK4, "$(P)$(R)ramp_down_sync.PROC")
+    field(DOL5, 1)
+    field(LNK5, "$(P)$(R)power_down_mode_sync.PROC")
+    field(DOL6, 1)
+    field(LNK6, "$(P)$(R)imon_range_sync.PROC")
+}
+record(seq, "$(P)$(R)current_sync") {
+    field(DOL0, "$(P)$(R)CH0:Current_RBV.VAL")
+    field(LNK0, "$(P)$(R)CH0:Current.VAL NPP")
+    field(DOL1, "$(P)$(R)CH1:Current_RBV.VAL")
+    field(LNK1, "$(P)$(R)CH1:Current.VAL NPP")
+    field(DOL2, "$(P)$(R)CH2:Current_RBV.VAL")
+    field(LNK2, "$(P)$(R)CH2:Current.VAL NPP")
+    field(DOL3, "$(P)$(R)CH3:Current_RBV.VAL")
+    field(LNK3, "$(P)$(R)CH3:Current.VAL NPP")
+    field(DOL4, "$(P)$(R)CH4:Current_RBV.VAL")
+    field(LNK4, "$(P)$(R)CH4:Current.VAL NPP")
+    field(DOL5, "$(P)$(R)CH5:Current_RBV.VAL")
+    field(LNK5, "$(P)$(R)CH5:Current.VAL NPP")
+    field(DOL6, "$(P)$(R)CH6:Current_RBV.VAL")
+    field(LNK6, "$(P)$(R)CH6:Current.VAL NPP")
+    field(DOL7, "$(P)$(R)CH7:Current_RBV.VAL")
+    field(LNK7, "$(P)$(R)CH7:Current.VAL NPP")
+}
+record(seq, "$(P)$(R)voltage_sync") {
+    field(DOL0, "$(P)$(R)CH0:Voltage_RBV.VAL")
+    field(LNK0, "$(P)$(R)CH0:Voltage.VAL NPP")
+    field(DOL1, "$(P)$(R)CH1:Voltage_RBV.VAL")
+    field(LNK1, "$(P)$(R)CH1:Voltage.VAL NPP")
+    field(DOL2, "$(P)$(R)CH2:Voltage_RBV.VAL")
+    field(LNK2, "$(P)$(R)CH2:Voltage.VAL NPP")
+    field(DOL3, "$(P)$(R)CH3:Voltage_RBV.VAL")
+    field(LNK3, "$(P)$(R)CH3:Voltage.VAL NPP")
+    field(DOL4, "$(P)$(R)CH4:Voltage_RBV.VAL")
+    field(LNK4, "$(P)$(R)CH4:Voltage.VAL NPP")
+    field(DOL5, "$(P)$(R)CH5:Voltage_RBV.VAL")
+    field(LNK5, "$(P)$(R)CH5:Voltage.VAL NPP")
+    field(DOL6, "$(P)$(R)CH6:Voltage_RBV.VAL")
+    field(LNK6, "$(P)$(R)CH6:Voltage.VAL NPP")
+    field(DOL7, "$(P)$(R)CH7:Voltage_RBV.VAL")
+    field(LNK7, "$(P)$(R)CH7:Voltage.VAL NPP")
+}
+record(seq, "$(P)$(R)power_sync") {
+    field(DOL0, "$(P)$(R)CH0:Power_RBV.VAL")
+    field(LNK0, "$(P)$(R)CH0:Power.VAL NPP")
+    field(DOL1, "$(P)$(R)CH1:Power_RBV.VAL")
+    field(LNK1, "$(P)$(R)CH1:Power.VAL NPP")
+    field(DOL2, "$(P)$(R)CH2:Power_RBV.VAL")
+    field(LNK2, "$(P)$(R)CH2:Power.VAL NPP")
+    field(DOL3, "$(P)$(R)CH3:Power_RBV.VAL")
+    field(LNK3, "$(P)$(R)CH3:Power.VAL NPP")
+    field(DOL4, "$(P)$(R)CH4:Power_RBV.VAL")
+    field(LNK4, "$(P)$(R)CH4:Power.VAL NPP")
+    field(DOL5, "$(P)$(R)CH5:Power_RBV.VAL")
+    field(LNK5, "$(P)$(R)CH5:Power.VAL NPP")
+    field(DOL6, "$(P)$(R)CH6:Power_RBV.VAL")
+    field(LNK6, "$(P)$(R)CH6:Power.VAL NPP")
+    field(DOL7, "$(P)$(R)CH7:Power_RBV.VAL")
+    field(LNK7, "$(P)$(R)CH7:Power.VAL NPP")
+}
+record(seq, "$(P)$(R)ramp_up_sync") {
+    field(DOL0, "$(P)$(R)CH0:RampUpRate_RBV.VAL")
+    field(LNK0, "$(P)$(R)CH0:RampUpRate.VAL NPP")
+    field(DOL1, "$(P)$(R)CH1:RampUpRate_RBV.VAL")
+    field(LNK1, "$(P)$(R)CH1:RampUpRate.VAL NPP")
+    field(DOL2, "$(P)$(R)CH2:RampUpRate_RBV.VAL")
+    field(LNK2, "$(P)$(R)CH2:RampUpRate.VAL NPP")
+    field(DOL3, "$(P)$(R)CH3:RampUpRate_RBV.VAL")
+    field(LNK3, "$(P)$(R)CH3:RampUpRate.VAL NPP")
+    field(DOL4, "$(P)$(R)CH4:RampUpRate_RBV.VAL")
+    field(LNK4, "$(P)$(R)CH4:RampUpRate.VAL NPP")
+    field(DOL5, "$(P)$(R)CH5:RampUpRate_RBV.VAL")
+    field(LNK5, "$(P)$(R)CH5:RampUpRate.VAL NPP")
+    field(DOL6, "$(P)$(R)CH6:RampUpRate_RBV.VAL")
+    field(LNK6, "$(P)$(R)CH6:RampUpRate.VAL NPP")
+    field(DOL7, "$(P)$(R)CH7:RampUpRate_RBV.VAL")
+    field(LNK7, "$(P)$(R)CH7:RampUpRate.VAL NPP")
+}
+record(seq, "$(P)$(R)ramp_down_sync") {
+    field(DOL0, "$(P)$(R)CH0:RampDownRate_RBV.VAL")
+    field(LNK0, "$(P)$(R)CH0:RampDownRate.VAL NPP")
+    field(DOL1, "$(P)$(R)CH1:RampDownRate_RBV.VAL")
+    field(LNK1, "$(P)$(R)CH1:RampDownRate.VAL NPP")
+    field(DOL2, "$(P)$(R)CH2:RampDownRate_RBV.VAL")
+    field(LNK2, "$(P)$(R)CH2:RampDownRate.VAL NPP")
+    field(DOL3, "$(P)$(R)CH3:RampDownRate_RBV.VAL")
+    field(LNK3, "$(P)$(R)CH3:RampDownRate.VAL NPP")
+    field(DOL4, "$(P)$(R)CH4:RampDownRate_RBV.VAL")
+    field(LNK4, "$(P)$(R)CH4:RampDownRate.VAL NPP")
+    field(DOL5, "$(P)$(R)CH5:RampDownRate_RBV.VAL")
+    field(LNK5, "$(P)$(R)CH5:RampDownRate.VAL NPP")
+    field(DOL6, "$(P)$(R)CH6:RampDownRate_RBV.VAL")
+    field(LNK6, "$(P)$(R)CH6:RampDownRate.VAL NPP")
+    field(DOL7, "$(P)$(R)CH7:RampDownRate_RBV.VAL")
+    field(LNK7, "$(P)$(R)CH7:RampDownRate.VAL NPP")
+}
+record(seq, "$(P)$(R)power_down_mode_sync") {
+    field(DOL0, "$(P)$(R)CH0:PowerDownMode_RBV.VAL")
+    field(LNK0, "$(P)$(R)CH0:PowerDownMode.VAL NPP")
+    field(DOL1, "$(P)$(R)CH1:PowerDownMode_RBV.VAL")
+    field(LNK1, "$(P)$(R)CH1:PowerDownMode.VAL NPP")
+    field(DOL2, "$(P)$(R)CH2:PowerDownMode_RBV.VAL")
+    field(LNK2, "$(P)$(R)CH2:PowerDownMode.VAL NPP")
+    field(DOL3, "$(P)$(R)CH3:PowerDownMode_RBV.VAL")
+    field(LNK3, "$(P)$(R)CH3:PowerDownMode.VAL NPP")
+    field(DOL4, "$(P)$(R)CH4:PowerDownMode_RBV.VAL")
+    field(LNK4, "$(P)$(R)CH4:PowerDownMode.VAL NPP")
+    field(DOL5, "$(P)$(R)CH5:PowerDownMode_RBV.VAL")
+    field(LNK5, "$(P)$(R)CH5:PowerDownMode.VAL NPP")
+    field(DOL6, "$(P)$(R)CH6:PowerDownMode_RBV.VAL")
+    field(LNK6, "$(P)$(R)CH6:PowerDownMode.VAL NPP")
+    field(DOL7, "$(P)$(R)CH7:PowerDownMode_RBV.VAL")
+    field(LNK7, "$(P)$(R)CH7:PowerDownMode.VAL NPP")
+}
+record(seq, "$(P)$(R)imon_range_sync") {
+    field(DOL0, "$(P)$(R)CH0:IMonRange_RBV.VAL")
+    field(LNK0, "$(P)$(R)CH0:IMonRange.VAL NPP")
+    field(DOL1, "$(P)$(R)CH1:IMonRange_RBV.VAL")
+    field(LNK1, "$(P)$(R)CH1:IMonRange.VAL NPP")
+    field(DOL2, "$(P)$(R)CH2:IMonRange_RBV.VAL")
+    field(LNK2, "$(P)$(R)CH2:IMonRange.VAL NPP")
+    field(DOL3, "$(P)$(R)CH3:IMonRange_RBV.VAL")
+    field(LNK3, "$(P)$(R)CH3:IMonRange.VAL NPP")
+    field(DOL4, "$(P)$(R)CH4:IMonRange_RBV.VAL")
+    field(LNK4, "$(P)$(R)CH4:IMonRange.VAL NPP")
+    field(DOL5, "$(P)$(R)CH5:IMonRange_RBV.VAL")
+    field(LNK5, "$(P)$(R)CH5:IMonRange.VAL NPP")
+    field(DOL6, "$(P)$(R)CH6:IMonRange_RBV.VAL")
+    field(LNK6, "$(P)$(R)CH6:IMonRange.VAL NPP")
+    field(DOL7, "$(P)$(R)CH7:IMonRange_RBV.VAL")
+    field(LNK7, "$(P)$(R)CH7:IMonRange.VAL NPP")
+}
+
+
+record(ai, "$(P)$(R)CH0:Voltage_RBV") {
+    field(EGU, "Volts")
+    field(PREC, 2)
+}
+record(ai, "$(P)$(R)CH1:Voltage_RBV") {
+    field(EGU, "Volts")
+    field(PREC, 2)
+}
+record(ai, "$(P)$(R)CH2:Voltage_RBV") {
+    field(EGU, "Volts")
+    field(PREC, 2)
+}
+record(ai, "$(P)$(R)CH3:Voltage_RBV") {
+    field(EGU, "Volts")
+    field(PREC, 2)
+}
+record(ai, "$(P)$(R)CH4:Voltage_RBV") {
+    field(EGU, "Volts")
+    field(PREC, 2)
+}
+record(ai, "$(P)$(R)CH5:Voltage_RBV") {
+    field(EGU, "Volts")
+    field(PREC, 2)
+}
+record(ai, "$(P)$(R)CH6:Voltage_RBV") {
+    field(EGU, "Volts")
+    field(PREC, 2)
+}
+record(ai, "$(P)$(R)CH7:Voltage_RBV") {
+    field(EGU, "Volts")
+    field(PREC, 2)
+}
+
+record(ai, "$(P)$(R)CH0:Current_RBV") {
+    field(EGU, "uA")
+    field(PREC, 3)
+}
+record(ai, "$(P)$(R)CH1:Current_RBV") {
+    field(EGU, "uA")
+    field(PREC, 3)
+}
+record(ai, "$(P)$(R)CH2:Current_RBV") {
+    field(EGU, "uA")
+    field(PREC, 3)
+}
+record(ai, "$(P)$(R)CH3:Current_RBV") {
+    field(EGU, "uA")
+    field(PREC, 3)
+}
+record(ai, "$(P)$(R)CH4:Current_RBV") {
+    field(EGU, "uA")
+    field(PREC, 3)
+}
+record(ai, "$(P)$(R)CH5:Current_RBV") {
+    field(EGU, "uA")
+    field(PREC, 3)
+}
+record(ai, "$(P)$(R)CH6:Current_RBV") {
+    field(EGU, "uA")
+    field(PREC, 3)
+}
+record(ai, "$(P)$(R)CH7:Current_RBV") {
+    field(EGU, "uA")
+    field(PREC, 3)
+}
+
+record(bi, "$(P)$(R)CH0:Power_RBV") { 
+    field(ZNAM, "OFF")
+    field(ONAM, "ON")
+}
+record(bi, "$(P)$(R)CH1:Power_RBV") { 
+    field(ZNAM, "OFF")
+    field(ONAM, "ON")
+}
+record(bi, "$(P)$(R)CH2:Power_RBV") { 
+    field(ZNAM, "OFF")
+    field(ONAM, "ON")
+}
+record(bi, "$(P)$(R)CH3:Power_RBV") { 
+    field(ZNAM, "OFF")
+    field(ONAM, "ON")
+}
+record(bi, "$(P)$(R)CH4:Power_RBV") { 
+    field(ZNAM, "OFF")
+    field(ONAM, "ON")
+}
+record(bi, "$(P)$(R)CH5:Power_RBV") { 
+    field(ZNAM, "OFF")
+    field(ONAM, "ON")
+}
+record(bi, "$(P)$(R)CH6:Power_RBV") { 
+    field(ZNAM, "OFF")
+    field(ONAM, "ON")
+}
+record(bi, "$(P)$(R)CH7:Power_RBV") { 
+    field(ZNAM, "OFF")
+    field(ONAM, "ON")
+}
+
+record(longin, "$(P)$(R)CH0:RampUpRate_RBV") {
+    field(EGU, "Volt/s")
+}
+record(longin, "$(P)$(R)CH1:RampUpRate_RBV") {
+    field(EGU, "Volt/s")
+}
+record(longin, "$(P)$(R)CH2:RampUpRate_RBV") {
+    field(EGU, "Volt/s")
+}
+record(longin, "$(P)$(R)CH3:RampUpRate_RBV") {
+    field(EGU, "Volt/s")
+}
+record(longin, "$(P)$(R)CH4:RampUpRate_RBV") {
+    field(EGU, "Volt/s")
+}
+record(longin, "$(P)$(R)CH5:RampUpRate_RBV") {
+    field(EGU, "Volt/s")
+}
+record(longin, "$(P)$(R)CH6:RampUpRate_RBV") {
+    field(EGU, "Volt/s")
+}
+record(longin, "$(P)$(R)CH7:RampUpRate_RBV") {
+    field(EGU, "Volt/s")
+}
+
+record(longin, "$(P)$(R)CH0:RampDownRate_RBV") {
+    field(EGU, "Volt/s")
+}
+record(longin, "$(P)$(R)CH1:RampDownRate_RBV") {
+    field(EGU, "Volt/s")
+}
+record(longin, "$(P)$(R)CH2:RampDownRate_RBV") {
+    field(EGU, "Volt/s")
+}
+record(longin, "$(P)$(R)CH3:RampDownRate_RBV") {
+    field(EGU, "Volt/s")
+}
+record(longin, "$(P)$(R)CH4:RampDownRate_RBV") {
+    field(EGU, "Volt/s")
+}
+record(longin, "$(P)$(R)CH5:RampDownRate_RBV") {
+    field(EGU, "Volt/s")
+}
+record(longin, "$(P)$(R)CH6:RampDownRate_RBV") {
+    field(EGU, "Volt/s")
+}
+record(longin, "$(P)$(R)CH7:RampDownRate_RBV") {
+    field(EGU, "Volt/s")
+}
+
+record(bi, "$(P)$(R)CH0:PowerDownMode_RBV") { 
+    field(ZNAM, "RAMP")
+    field(ONAM, "KILL")
+}
+record(bi, "$(P)$(R)CH1:PowerDownMode_RBV") { 
+    field(ZNAM, "RAMP")
+    field(ONAM, "KILL")
+}
+record(bi, "$(P)$(R)CH2:PowerDownMode_RBV") { 
+    field(ZNAM, "RAMP")
+    field(ONAM, "KILL")
+}
+record(bi, "$(P)$(R)CH3:PowerDownMode_RBV") { 
+    field(ZNAM, "RAMP")
+    field(ONAM, "KILL")
+}
+record(bi, "$(P)$(R)CH4:PowerDownMode_RBV") { 
+    field(ZNAM, "RAMP")
+    field(ONAM, "KILL")
+}
+record(bi, "$(P)$(R)CH5:PowerDownMode_RBV") { 
+    field(ZNAM, "RAMP")
+    field(ONAM, "KILL")
+}
+record(bi, "$(P)$(R)CH6:PowerDownMode_RBV") { 
+    field(ZNAM, "RAMP")
+    field(ONAM, "KILL")
+}
+record(bi, "$(P)$(R)CH7:PowerDownMode_RBV") { 
+    field(ZNAM, "RAMP")
+    field(ONAM, "KILL")
+}
+
+record(bi, "$(P)$(R)CH0:IMonRange_RBV") { 
+    field(ZNAM, "HIGH")
+    field(ONAM, "LOW")
+}
+record(bi, "$(P)$(R)CH1:IMonRange_RBV") { 
+    field(ZNAM, "HIGH")
+    field(ONAM, "LOW")
+}
+record(bi, "$(P)$(R)CH2:IMonRange_RBV") { 
+    field(ZNAM, "HIGH")
+    field(ONAM, "LOW")
+}
+record(bi, "$(P)$(R)CH3:IMonRange_RBV") { 
+    field(ZNAM, "HIGH")
+    field(ONAM, "LOW")
+}
+record(bi, "$(P)$(R)CH4:IMonRange_RBV") { 
+    field(ZNAM, "HIGH")
+    field(ONAM, "LOW")
+}
+record(bi, "$(P)$(R)CH5:IMonRange_RBV") { 
+    field(ZNAM, "HIGH")
+    field(ONAM, "LOW")
+}
+record(bi, "$(P)$(R)CH6:IMonRange_RBV") { 
+    field(ZNAM, "HIGH")
+    field(ONAM, "LOW")
+}
+record(bi, "$(P)$(R)CH7:IMonRange_RBV") { 
+    field(ZNAM, "HIGH")
+    field(ONAM, "LOW")
+}
+
+record(bo, "$(P)$(R)CH0:Power") {
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto set_power(0) $(PORT)")
+    field(ZNAM, "OFF")
+    field(ONAM, "ON")
+}
+record(bo, "$(P)$(R)CH1:Power") {
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto set_power(1) $(PORT)")
+    field(ZNAM, "OFF")
+    field(ONAM, "ON")
+}
+record(bo, "$(P)$(R)CH2:Power") {
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto set_power(2) $(PORT)")
+    field(ZNAM, "OFF")
+    field(ONAM, "ON")
+}
+record(bo, "$(P)$(R)CH3:Power") {
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto set_power(3) $(PORT)")
+    field(ZNAM, "OFF")
+    field(ONAM, "ON")
+}
+record(bo, "$(P)$(R)CH4:Power") {
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto set_power(4) $(PORT)")
+    field(ZNAM, "OFF")
+    field(ONAM, "ON")
+}
+record(bo, "$(P)$(R)CH5:Power") {
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto set_power(5) $(PORT)")
+    field(ZNAM, "OFF")
+    field(ONAM, "ON")
+}
+record(bo, "$(P)$(R)CH6:Power") {
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto set_power(6) $(PORT)")
+    field(ZNAM, "OFF")
+    field(ONAM, "ON")
+}
+record(bo, "$(P)$(R)CH7:Power") {
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto set_power(7) $(PORT)")
+    field(ZNAM, "OFF")
+    field(ONAM, "ON")
+}
+
+record(ao, "$(P)$(R)CH0:Voltage") {
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto set_voltage(0) $(PORT)")
+    field(PREC, 2)
+}
+record(ao, "$(P)$(R)CH1:Voltage") {
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto set_voltage(1) $(PORT)")
+    field(PREC, 2)
+}
+record(ao, "$(P)$(R)CH2:Voltage") {
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto set_voltage(2) $(PORT)")
+    field(PREC, 2)
+}
+record(ao, "$(P)$(R)CH3:Voltage") {
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto set_voltage(3) $(PORT)")
+    field(PREC, 2)
+}
+record(ao, "$(P)$(R)CH4:Voltage") {
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto set_voltage(4) $(PORT)")
+    field(PREC, 2)
+}
+record(ao, "$(P)$(R)CH5:Voltage") {
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto set_voltage(5) $(PORT)")
+    field(PREC, 2)
+}
+record(ao, "$(P)$(R)CH6:Voltage") {
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto set_voltage(6) $(PORT)")
+    field(PREC, 2)
+}
+record(ao, "$(P)$(R)CH7:Voltage") {
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto set_voltage(7) $(PORT)")
+    field(PREC, 2)
+}
+
+record(ao, "$(P)$(R)CH0:Current") {
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto set_current(0) $(PORT)")
+    field(PREC, 3)
+}
+record(ao, "$(P)$(R)CH1:Current") {
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto set_current(1) $(PORT)")
+    field(PREC, 3)
+}
+record(ao, "$(P)$(R)CH2:Current") {
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto set_current(2) $(PORT)")
+    field(PREC, 3)
+}
+record(ao, "$(P)$(R)CH3:Current") {
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto set_current(3) $(PORT)")
+    field(PREC, 3)
+}
+record(ao, "$(P)$(R)CH4:Current") {
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto set_current(4) $(PORT)")
+    field(PREC, 3)
+}
+record(ao, "$(P)$(R)CH5:Current") {
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto set_current(5) $(PORT)")
+    field(PREC, 3)
+}
+record(ao, "$(P)$(R)CH6:Current") {
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto set_current(6) $(PORT)")
+    field(PREC, 3)
+}
+record(ao, "$(P)$(R)CH7:Current") {
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto set_current(7) $(PORT)")
+    field(PREC, 3)
+}
+
+record(longout, "$(P)$(R)CH0:RampUpRate") {
+    field(EGU, "Volt/sec")
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto set_ramp_up(0) $(PORT)")
+}
+record(longout, "$(P)$(R)CH1:RampUpRate") {
+    field(EGU, "Volt/sec")
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto set_ramp_up(1) $(PORT)")
+}
+record(longout, "$(P)$(R)CH2:RampUpRate") {
+    field(EGU, "Volt/sec")
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto set_ramp_up(2) $(PORT)")
+}
+record(longout, "$(P)$(R)CH3:RampUpRate") {
+    field(EGU, "Volt/sec")
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto set_ramp_up(3) $(PORT)")
+}
+record(longout, "$(P)$(R)CH4:RampUpRate") {
+    field(EGU, "Volt/sec")
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto set_ramp_up(4) $(PORT)")
+}
+record(longout, "$(P)$(R)CH5:RampUpRate") {
+    field(EGU, "Volt/sec")
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto set_ramp_up(5) $(PORT)")
+}
+record(longout, "$(P)$(R)CH6:RampUpRate") {
+    field(EGU, "Volt/sec")
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto set_ramp_up(6) $(PORT)")
+}
+record(longout, "$(P)$(R)CH7:RampUpRate") {
+    field(EGU, "Volt/sec")
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto set_ramp_up(7) $(PORT)")
+}
+
+record(longout, "$(P)$(R)CH0:RampDownRate") {
+    field(EGU, "Volt/sec")
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto set_ramp_down(0) $(PORT)")
+}
+record(longout, "$(P)$(R)CH1:RampDownRate") {
+    field(EGU, "Volt/sec")
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto set_ramp_down(1) $(PORT)")
+}
+record(longout, "$(P)$(R)CH2:RampDownRate") {
+    field(EGU, "Volt/sec")
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto set_ramp_down(2) $(PORT)")
+}
+record(longout, "$(P)$(R)CH3:RampDownRate") {
+    field(EGU, "Volt/sec")
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto set_ramp_down(3) $(PORT)")
+}
+record(longout, "$(P)$(R)CH4:RampDownRate") {
+    field(EGU, "Volt/sec")
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto set_ramp_down(4) $(PORT)")
+}
+record(longout, "$(P)$(R)CH5:RampDownRate") {
+    field(EGU, "Volt/sec")
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto set_ramp_down(5) $(PORT)")
+}
+record(longout, "$(P)$(R)CH6:RampDownRate") {
+    field(EGU, "Volt/sec")
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto set_ramp_down(6) $(PORT)")
+}
+record(longout, "$(P)$(R)CH7:RampDownRate") {
+    field(EGU, "Volt/sec")
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto set_ramp_down(7) $(PORT)")
+}
+
+record(bo, "$(P)$(R)CH0:PowerDownMode") {
+    field(VAL, 1)
+    field(ZNAM, "RAMP")
+    field(ONAM, "KILL")
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto set_power_down_mode(0) $(PORT)")
+}
+record(bo, "$(P)$(R)CH1:PowerDownMode") {
+    field(ZNAM, "RAMP")
+    field(ONAM, "KILL")
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto set_power_down_mode(1) $(PORT)")
+}
+record(bo, "$(P)$(R)CH2:PowerDownMode") {
+    field(ZNAM, "RAMP")
+    field(ONAM, "KILL")
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto set_power_down_mode(2) $(PORT)")
+}
+record(bo, "$(P)$(R)CH3:PowerDownMode") {
+    field(ZNAM, "RAMP")
+    field(ONAM, "KILL")
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto set_power_down_mode(3) $(PORT)")
+}
+record(bo, "$(P)$(R)CH4:PowerDownMode") {
+    field(ZNAM, "RAMP")
+    field(ONAM, "KILL")
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto set_power_down_mode(4) $(PORT)")
+}
+record(bo, "$(P)$(R)CH5:PowerDownMode") {
+    field(ZNAM, "RAMP")
+    field(ONAM, "KILL")
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto set_power_down_mode(5) $(PORT)")
+}
+record(bo, "$(P)$(R)CH6:PowerDownMode") {
+    field(ZNAM, "RAMP")
+    field(ONAM, "KILL")
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto set_power_down_mode(6) $(PORT)")
+}
+record(bo, "$(P)$(R)CH7:PowerDownMode") {
+    field(ZNAM, "RAMP")
+    field(ONAM, "KILL")
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto set_power_down_mode(7) $(PORT)")
+}
+
+record(bo, "$(P)$(R)CH0:IMonRange") {
+    field(ZNAM, "HIGH")
+    field(ONAM, "LOW")
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto set_imon_range(0) $(PORT)")
+}
+record(bo, "$(P)$(R)CH1:IMonRange") {
+    field(ZNAM, "HIGH")
+    field(ONAM, "LOW")
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto set_imon_range(1) $(PORT)")
+}
+record(bo, "$(P)$(R)CH2:IMonRange") {
+    field(ZNAM, "HIGH")
+    field(ONAM, "LOW")
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto set_imon_range(2) $(PORT)")
+}
+record(bo, "$(P)$(R)CH3:IMonRange") {
+    field(ZNAM, "HIGH")
+    field(ONAM, "LOW")
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto set_imon_range(3) $(PORT)")
+}
+record(bo, "$(P)$(R)CH4:IMonRange") {
+    field(ZNAM, "HIGH")
+    field(ONAM, "LOW")
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto set_imon_range(4) $(PORT)")
+}
+record(bo, "$(P)$(R)CH5:IMonRange") {
+    field(ZNAM, "HIGH")
+    field(ONAM, "LOW")
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto set_imon_range(5) $(PORT)")
+}
+record(bo, "$(P)$(R)CH6:IMonRange") {
+    field(ZNAM, "HIGH")
+    field(ONAM, "LOW")
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto set_imon_range(6) $(PORT)")
+}
+record(bo, "$(P)$(R)CH7:IMonRange") {
+    field(ZNAM, "HIGH")
+    field(ONAM, "LOW")
+    field(DTYP, "stream")
+    field(OUT,  "@caen_N8031.proto set_imon_range(7) $(PORT)")
+}
+
+record(stringout, "$(P)$(R)CH0:Name") {}
+record(stringout, "$(P)$(R)CH1:Name") {}
+record(stringout, "$(P)$(R)CH2:Name") {}
+record(stringout, "$(P)$(R)CH3:Name") {}
+record(stringout, "$(P)$(R)CH4:Name") {}
+record(stringout, "$(P)$(R)CH5:Name") {}
+record(stringout, "$(P)$(R)CH6:Name") {}
+record(stringout, "$(P)$(R)CH7:Name") {}

--- a/ipApp/Db/caen_N8031.proto
+++ b/ipApp/Db/caen_N8031.proto
@@ -1,0 +1,128 @@
+OutTerminator = CR LF;
+InTerminator = CR LF;
+
+read_voltages {
+    out "$CMD:MON,CH:8,PAR:VMON";
+    in
+        "#CMD:OK,VAL:"
+        "%(\$1CH0:Voltage_RBV)f;"
+        "%(\$1CH1:Voltage_RBV)f;"
+        "%(\$1CH2:Voltage_RBV)f;"
+        "%(\$1CH3:Voltage_RBV)f;"
+        "%(\$1CH4:Voltage_RBV)f;"
+        "%(\$1CH5:Voltage_RBV)f;"
+        "%(\$1CH6:Voltage_RBV)f;"
+        "%(\$1CH7:Voltage_RBV)f";
+}
+
+read_currents {
+    out "$CMD:MON,CH:8,PAR:IMON";
+    in
+        "#CMD:OK,VAL:"
+        "%(\$1CH0:Current_RBV)f;"
+        "%(\$1CH1:Current_RBV)f;"
+        "%(\$1CH2:Current_RBV)f;"
+        "%(\$1CH3:Current_RBV)f;"
+        "%(\$1CH4:Current_RBV)f;"
+        "%(\$1CH5:Current_RBV)f;"
+        "%(\$1CH6:Current_RBV)f;"
+        "%(\$1CH7:Current_RBV)f";
+}
+
+read_power_states {
+    out "$CMD:MON,CH:8,PAR:PW";
+    in
+        "#CMD:OK,VAL:"
+        "%(\$1CH0:Power_RBV){OFF|ON};"
+        "%(\$1CH1:Power_RBV){OFF|ON};"
+        "%(\$1CH2:Power_RBV){OFF|ON};"
+        "%(\$1CH3:Power_RBV){OFF|ON};"
+        "%(\$1CH4:Power_RBV){OFF|ON};"
+        "%(\$1CH5:Power_RBV){OFF|ON};"
+        "%(\$1CH6:Power_RBV){OFF|ON};"
+        "%(\$1CH7:Power_RBV){OFF|ON}";
+}
+
+read_ramp_up_rates {
+    out "$CMD:MON,CH:8,PAR:RUP";
+    in
+        "#CMD:OK,VAL:"
+        "%(\$1CH0:RampUpRate_RBV)d;"
+        "%(\$1CH1:RampUpRate_RBV)d;"
+        "%(\$1CH2:RampUpRate_RBV)d;"
+        "%(\$1CH3:RampUpRate_RBV)d;"
+        "%(\$1CH4:RampUpRate_RBV)d;"
+        "%(\$1CH5:RampUpRate_RBV)d;"
+        "%(\$1CH6:RampUpRate_RBV)d;"
+        "%(\$1CH7:RampUpRate_RBV)d";
+}
+
+read_ramp_down_rates {
+    out "$CMD:MON,CH:8,PAR:RDWN";
+    in
+        "#CMD:OK,VAL:"
+        "%(\$1CH0:RampDownRate_RBV)d;"
+        "%(\$1CH1:RampDownRate_RBV)d;"
+        "%(\$1CH2:RampDownRate_RBV)d;"
+        "%(\$1CH3:RampDownRate_RBV)d;"
+        "%(\$1CH4:RampDownRate_RBV)d;"
+        "%(\$1CH5:RampDownRate_RBV)d;"
+        "%(\$1CH6:RampDownRate_RBV)d;"
+        "%(\$1CH7:RampDownRate_RBV)d";
+}
+
+read_power_down_modes {
+    out "$CMD:MON,CH:8,PAR:PDWN";
+    in
+        "#CMD:OK,VAL:"
+        "%(\$1CH0:PowerDownMode_RBV){RAMP|KILL};"
+        "%(\$1CH1:PowerDownMode_RBV){RAMP|KILL};"
+        "%(\$1CH2:PowerDownMode_RBV){RAMP|KILL};"
+        "%(\$1CH3:PowerDownMode_RBV){RAMP|KILL};"
+        "%(\$1CH4:PowerDownMode_RBV){RAMP|KILL};"
+        "%(\$1CH5:PowerDownMode_RBV){RAMP|KILL};"
+        "%(\$1CH6:PowerDownMode_RBV){RAMP|KILL};"
+        "%(\$1CH7:PowerDownMode_RBV){RAMP|KILL}";
+}
+
+read_imon_ranges {
+    out "$CMD:MON,CH:8,PAR:IMRANGE";
+    in
+        "#CMD:OK,VAL:"
+        "%(\$1CH0:IMonRange_RBV){HIGH|LOW};"
+        "%(\$1CH1:IMonRange_RBV){HIGH|LOW};"
+        "%(\$1CH2:IMonRange_RBV){HIGH|LOW};"
+        "%(\$1CH3:IMonRange_RBV){HIGH|LOW};"
+        "%(\$1CH4:IMonRange_RBV){HIGH|LOW};"
+        "%(\$1CH5:IMonRange_RBV){HIGH|LOW};"
+        "%(\$1CH6:IMonRange_RBV){HIGH|LOW};"
+        "%(\$1CH7:IMonRange_RBV){HIGH|LOW}";
+}
+
+set_power {
+    out "$CMD:SET,CH:\$1,PAR:PW,VAL:%{OFF|ON}";
+}
+
+set_voltage {
+    out "$CMD:SET,CH:\$1,PAR:VSET,VAL:%f";
+}
+
+set_current {
+    out "$CMD:SET,CH:\$1,PAR:VSET,VAL:%f";
+}
+
+set_ramp_up {
+    out "$CMD:SET,CH:\$1,PAR:RUP,VAL:%d";
+}
+
+set_ramp_down {
+    out "$CMD:SET,CH:\$1,PAR:RDWN,VAL:%d";
+}
+
+set_power_down_mode {
+    out "$CMD:SET,CH:\$1,PAR:PDWN,VAL:%{RAMP|KILL}";
+}
+
+set_imon_range {
+    out "$CMD:SET,CH:\$1,PAR:IMRANGE,VAL:%{HIGH|LOW}";
+}

--- a/ipApp/Db/caen_N8031_settings.req
+++ b/ipApp/Db/caen_N8031_settings.req
@@ -1,0 +1,8 @@
+$(P)$(R)CH0:Name.VAL
+$(P)$(R)CH1:Name.VAL
+$(P)$(R)CH2:Name.VAL
+$(P)$(R)CH3:Name.VAL
+$(P)$(R)CH4:Name.VAL
+$(P)$(R)CH5:Name.VAL
+$(P)$(R)CH6:Name.VAL
+$(P)$(R)CH7:Name.VAL

--- a/ipApp/op/ui/caen_N8031.ui
+++ b/ipApp/op/ui/caen_N8031.ui
@@ -1,0 +1,4314 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>MainWindow</class>
+ <widget class="QMainWindow" name="MainWindow">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>1198</width>
+    <height>484</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string/>
+  </property>
+  <property name="styleSheet">
+   <string notr="true">QWidget#centralWidget {background: rgba(196, 196, 196, 255);}
+
+caTable {
+       background: cornsilk;
+       alternate-background-color: wheat;
+}
+
+caLineEdit {
+     border-radius: 1px;
+     background: lightyellow;
+     color: black;
+ }
+ 
+ caLabel {
+     border-radius: 1px;
+     background: lightyellow;
+     color: black;
+ }
+
+caTextEntry {
+    color: rgb(127, 0, 63);
+    background-color: cornsilk;
+    selection-color: #0a214c;
+    selection-background-color: wheat;
+    border: 1px groove black;
+    border-radius: 1px;
+    padding: 1px;
+}
+
+caTextEntry:focus {
+    padding: 0px;
+    border: 2px groove darkred;
+    border-radius: 1px;
+}
+
+/* when font specified, no font sizing is done any more,  font: 10pt; is not bad */
+QPushButton {
+      border-color: #00b;
+      border-radius: 2px;
+      padding: 3px;
+      border-width: 1px;
+
+	background: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1,
+						   stop:0   rgba(224, 239, 255, 255),
+						   stop:0.5 rgba(199, 215, 230, 255),
+						   stop:1   rgba(184, 214, 236, 255));
+}
+QPushButton:hover {
+	background: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1,
+						stop:0   rgba(201, 226, 255, 255),
+						stop:0.5 rgba(177, 204, 230, 255),
+						stop:1   rgba(163, 205, 236, 255));
+}
+QPushButton:pressed {
+	background: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1,
+						stop:0   rgba(174, 219, 255, 255),
+						stop:0.5 rgba(165, 199, 230, 255),
+						stop:1   rgba(134, 188, 236, 255));
+}
+
+QPushButton:disabled {
+	background: qlineargradient(spread:pad, x1:0, y1:0, x2:0, y2:1,
+						stop:0   rgba(174, 219, 255, 255),
+						stop:0.5 rgba(165, 199, 230, 255),
+						stop:1   rgba(134, 188, 236, 255));
+}
+
+
+caChoice &gt; QPushButton {
+text-align: left;
+background-color: rgba(87, 202, 228,255);
+border: 3px gray;
+}
+
+caChoice &gt; QPushButton:pressed {
+background-color: rgba(87, 202, 228,200);
+border: 3px gray;
+}
+
+caChoice &gt; QPushButton:checked {
+background-color: rgba(87, 202, 228,200);
+border: 3px gray;
+}
+
+caChoice &gt; QPushButton:default {
+background-color: lightgray;
+border: 3px gray;
+}
+
+caMenu{
+    background: lightyellow;
+}
+
+
+
+
+</string>
+  </property>
+  <widget class="QWidget" name="centralWidget">
+   <property name="styleSheet">
+    <string notr="true"/>
+   </property>
+   <widget class="caLineEdit" name="caLineEdit_17">
+    <property name="geometry">
+     <rect>
+      <x>530</x>
+      <y>180</y>
+      <width>100</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>$(P)$(R)CH3:Voltage_RBV</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH3:Voltage_RBV.VAL</string>
+    </property>
+    <property name="foreground">
+     <color>
+      <red>0</red>
+      <green>0</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="background">
+     <color>
+      <red>196</red>
+      <green>196</green>
+      <blue>196</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+    <property name="precisionMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="limitsMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="maxValue">
+     <double>1.000000000000000</double>
+    </property>
+    <property name="minValue">
+     <double>0.000000000000000</double>
+    </property>
+    <property name="fontScaleMode" stdset="0">
+     <enum>caLineEdit::WidthAndHeight</enum>
+    </property>
+    <property name="formatType">
+     <enum>caLineEdit::decimal</enum>
+    </property>
+   </widget>
+   <widget class="caLineEdit" name="caLineEdit_15">
+    <property name="geometry">
+     <rect>
+      <x>405</x>
+      <y>180</y>
+      <width>100</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>$(P)$(R)CH2:Voltage_RBV</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH2:Voltage_RBV.VAL</string>
+    </property>
+    <property name="foreground">
+     <color>
+      <red>0</red>
+      <green>0</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="background">
+     <color>
+      <red>196</red>
+      <green>196</green>
+      <blue>196</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+    <property name="precisionMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="limitsMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="maxValue">
+     <double>1.000000000000000</double>
+    </property>
+    <property name="minValue">
+     <double>0.000000000000000</double>
+    </property>
+    <property name="fontScaleMode" stdset="0">
+     <enum>caLineEdit::WidthAndHeight</enum>
+    </property>
+    <property name="formatType">
+     <enum>caLineEdit::decimal</enum>
+    </property>
+   </widget>
+   <widget class="caLineEdit" name="caLineEdit_14">
+    <property name="geometry">
+     <rect>
+      <x>145</x>
+      <y>180</y>
+      <width>100</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="inputMask">
+     <string/>
+    </property>
+    <property name="text">
+     <string>$(P)$(R)CH0:Voltage_RBV</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH0:Voltage_RBV.VAL</string>
+    </property>
+    <property name="foreground">
+     <color>
+      <red>0</red>
+      <green>0</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="background">
+     <color>
+      <red>196</red>
+      <green>196</green>
+      <blue>196</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+    <property name="precisionMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="limitsMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="maxValue">
+     <double>1.000000000000000</double>
+    </property>
+    <property name="minValue">
+     <double>0.000000000000000</double>
+    </property>
+    <property name="fontScaleMode" stdset="0">
+     <enum>caLineEdit::WidthAndHeight</enum>
+    </property>
+    <property name="formatType">
+     <enum>caLineEdit::decimal</enum>
+    </property>
+   </widget>
+   <widget class="caLineEdit" name="caLineEdit_16">
+    <property name="geometry">
+     <rect>
+      <x>655</x>
+      <y>180</y>
+      <width>100</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>$(P)$(R)CH4:Voltage_RBV</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH4:Voltage_RBV.VAL</string>
+    </property>
+    <property name="foreground">
+     <color>
+      <red>0</red>
+      <green>0</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="background">
+     <color>
+      <red>196</red>
+      <green>196</green>
+      <blue>196</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+    <property name="precisionMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="limitsMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="maxValue">
+     <double>1.000000000000000</double>
+    </property>
+    <property name="minValue">
+     <double>0.000000000000000</double>
+    </property>
+    <property name="fontScaleMode" stdset="0">
+     <enum>caLineEdit::WidthAndHeight</enum>
+    </property>
+    <property name="formatType">
+     <enum>caLineEdit::decimal</enum>
+    </property>
+   </widget>
+   <widget class="caTextEntry" name="catextentry_4">
+    <property name="geometry">
+     <rect>
+      <x>145</x>
+      <y>200</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH0:Voltage.VAL</string>
+    </property>
+    <property name="background">
+     <color>
+      <red>115</red>
+      <green>223</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+   </widget>
+   <widget class="caTextEntry" name="catextentry_5">
+    <property name="geometry">
+     <rect>
+      <x>405</x>
+      <y>200</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH2:Voltage.VAL</string>
+    </property>
+    <property name="background">
+     <color>
+      <red>115</red>
+      <green>223</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+   </widget>
+   <widget class="caTextEntry" name="catextentry_6">
+    <property name="geometry">
+     <rect>
+      <x>530</x>
+      <y>200</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH3:Voltage.VAL</string>
+    </property>
+    <property name="background">
+     <color>
+      <red>115</red>
+      <green>223</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+   </widget>
+   <widget class="caTextEntry" name="catextentry_7">
+    <property name="geometry">
+     <rect>
+      <x>655</x>
+      <y>200</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH4:Voltage.VAL</string>
+    </property>
+    <property name="background">
+     <color>
+      <red>115</red>
+      <green>223</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+   </widget>
+   <widget class="caLabel" name="caLabel_45">
+    <property name="geometry">
+     <rect>
+      <x>5</x>
+      <y>2</y>
+      <width>326</width>
+      <height>30</height>
+     </rect>
+    </property>
+    <property name="font">
+     <font>
+      <pointsize>18</pointsize>
+      <weight>75</weight>
+      <bold>true</bold>
+     </font>
+    </property>
+    <property name="text">
+     <string>CAEN N8031 Power Supply</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignAbsolute|Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+    </property>
+    <property name="fontScaleMode">
+     <enum>ESimpleLabel::WidthAndHeight</enum>
+    </property>
+    <property name="foreground">
+     <color>
+      <red>255</red>
+      <green>255</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="background">
+     <color alpha="0">
+      <red>0</red>
+      <green>0</green>
+      <blue>0</blue>
+     </color>
+    </property>
+    <property name="frameShape">
+     <enum>QFrame::NoFrame</enum>
+    </property>
+   </widget>
+   <widget class="caFrame" name="caframe_8">
+    <property name="geometry">
+     <rect>
+      <x>0</x>
+      <y>0</y>
+      <width>1431</width>
+      <height>35</height>
+     </rect>
+    </property>
+    <property name="lineWidth">
+     <number>0</number>
+    </property>
+    <property name="background">
+     <color>
+      <red>0</red>
+      <green>53</green>
+      <blue>132</blue>
+     </color>
+    </property>
+    <property name="backgroundMode">
+     <enum>caFrame::Filled</enum>
+    </property>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <property name="spacing">
+      <number>5</number>
+     </property>
+     <property name="leftMargin">
+      <number>10</number>
+     </property>
+     <property name="topMargin">
+      <number>2</number>
+     </property>
+     <property name="rightMargin">
+      <number>0</number>
+     </property>
+     <property name="bottomMargin">
+      <number>2</number>
+     </property>
+    </layout>
+   </widget>
+   <widget class="caLineEdit" name="caLineEdit_18">
+    <property name="geometry">
+     <rect>
+      <x>905</x>
+      <y>180</y>
+      <width>100</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>$(P)$(R)CH6:Voltage_RBV</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH6:Voltage_RBV.VAL</string>
+    </property>
+    <property name="foreground">
+     <color>
+      <red>0</red>
+      <green>0</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="background">
+     <color>
+      <red>196</red>
+      <green>196</green>
+      <blue>196</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+    <property name="precisionMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="limitsMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="maxValue">
+     <double>1.000000000000000</double>
+    </property>
+    <property name="minValue">
+     <double>0.000000000000000</double>
+    </property>
+    <property name="fontScaleMode" stdset="0">
+     <enum>caLineEdit::WidthAndHeight</enum>
+    </property>
+    <property name="formatType">
+     <enum>caLineEdit::decimal</enum>
+    </property>
+   </widget>
+   <widget class="caTextEntry" name="catextentry_8">
+    <property name="geometry">
+     <rect>
+      <x>275</x>
+      <y>200</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH1:Voltage.VAL</string>
+    </property>
+    <property name="background">
+     <color>
+      <red>115</red>
+      <green>223</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+   </widget>
+   <widget class="caTextEntry" name="catextentry_9">
+    <property name="geometry">
+     <rect>
+      <x>1030</x>
+      <y>200</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH7:Voltage.VAL</string>
+    </property>
+    <property name="background">
+     <color>
+      <red>115</red>
+      <green>223</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+   </widget>
+   <widget class="caTextEntry" name="catextentry_10">
+    <property name="geometry">
+     <rect>
+      <x>905</x>
+      <y>200</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH6:Voltage.VAL</string>
+    </property>
+    <property name="background">
+     <color>
+      <red>115</red>
+      <green>223</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+   </widget>
+   <widget class="caLineEdit" name="caLineEdit_19">
+    <property name="geometry">
+     <rect>
+      <x>780</x>
+      <y>180</y>
+      <width>100</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>$(P)$(R)CH5:Voltage_RBV</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH5:Voltage_RBV.VAL</string>
+    </property>
+    <property name="foreground">
+     <color>
+      <red>0</red>
+      <green>0</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="background">
+     <color>
+      <red>196</red>
+      <green>196</green>
+      <blue>196</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+    <property name="precisionMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="limitsMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="maxValue">
+     <double>1.000000000000000</double>
+    </property>
+    <property name="minValue">
+     <double>0.000000000000000</double>
+    </property>
+    <property name="fontScaleMode" stdset="0">
+     <enum>caLineEdit::WidthAndHeight</enum>
+    </property>
+    <property name="formatType">
+     <enum>caLineEdit::decimal</enum>
+    </property>
+   </widget>
+   <widget class="caLineEdit" name="caLineEdit_20">
+    <property name="geometry">
+     <rect>
+      <x>1030</x>
+      <y>180</y>
+      <width>100</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>$(P)$(R)CH7:Voltage_RBV</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH7:Voltage_RBV.VAL</string>
+    </property>
+    <property name="foreground">
+     <color>
+      <red>0</red>
+      <green>0</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="background">
+     <color>
+      <red>196</red>
+      <green>196</green>
+      <blue>196</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+    <property name="precisionMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="limitsMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="maxValue">
+     <double>1.000000000000000</double>
+    </property>
+    <property name="minValue">
+     <double>0.000000000000000</double>
+    </property>
+    <property name="fontScaleMode" stdset="0">
+     <enum>caLineEdit::WidthAndHeight</enum>
+    </property>
+    <property name="formatType">
+     <enum>caLineEdit::decimal</enum>
+    </property>
+   </widget>
+   <widget class="caLineEdit" name="caLineEdit_21">
+    <property name="geometry">
+     <rect>
+      <x>275</x>
+      <y>180</y>
+      <width>100</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="inputMask">
+     <string/>
+    </property>
+    <property name="text">
+     <string>$(P)$(R)CH1:Voltage_RBV</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH1:Voltage_RBV.VAL</string>
+    </property>
+    <property name="foreground">
+     <color>
+      <red>0</red>
+      <green>0</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="background">
+     <color>
+      <red>196</red>
+      <green>196</green>
+      <blue>196</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+    <property name="precisionMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="limitsMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="maxValue">
+     <double>1.000000000000000</double>
+    </property>
+    <property name="minValue">
+     <double>0.000000000000000</double>
+    </property>
+    <property name="fontScaleMode" stdset="0">
+     <enum>caLineEdit::WidthAndHeight</enum>
+    </property>
+    <property name="formatType">
+     <enum>caLineEdit::decimal</enum>
+    </property>
+   </widget>
+   <widget class="caTextEntry" name="catextentry_11">
+    <property name="geometry">
+     <rect>
+      <x>780</x>
+      <y>200</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH5:Voltage.VAL</string>
+    </property>
+    <property name="background">
+     <color>
+      <red>115</red>
+      <green>223</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+   </widget>
+   <widget class="caLineEdit" name="caLineEdit_22">
+    <property name="geometry">
+     <rect>
+      <x>530</x>
+      <y>245</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>$(P)$(R)CH3:Current_RBV</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH3:Current_RBV.VAL</string>
+    </property>
+    <property name="foreground">
+     <color>
+      <red>0</red>
+      <green>0</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="background">
+     <color>
+      <red>196</red>
+      <green>196</green>
+      <blue>196</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+    <property name="precisionMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="limitsMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="maxValue">
+     <double>1.000000000000000</double>
+    </property>
+    <property name="minValue">
+     <double>0.000000000000000</double>
+    </property>
+    <property name="fontScaleMode" stdset="0">
+     <enum>caLineEdit::WidthAndHeight</enum>
+    </property>
+    <property name="formatType">
+     <enum>caLineEdit::decimal</enum>
+    </property>
+   </widget>
+   <widget class="caLineEdit" name="caLineEdit_23">
+    <property name="geometry">
+     <rect>
+      <x>905</x>
+      <y>245</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>$(P)$(R)CH6:Current_RBV.VAL</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH6:Current_RBV.VAL</string>
+    </property>
+    <property name="foreground">
+     <color>
+      <red>0</red>
+      <green>0</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="background">
+     <color>
+      <red>196</red>
+      <green>196</green>
+      <blue>196</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+    <property name="precisionMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="limitsMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="maxValue">
+     <double>1.000000000000000</double>
+    </property>
+    <property name="minValue">
+     <double>0.000000000000000</double>
+    </property>
+    <property name="fontScaleMode" stdset="0">
+     <enum>caLineEdit::WidthAndHeight</enum>
+    </property>
+    <property name="formatType">
+     <enum>caLineEdit::decimal</enum>
+    </property>
+   </widget>
+   <widget class="caLineEdit" name="caLineEdit_24">
+    <property name="geometry">
+     <rect>
+      <x>1030</x>
+      <y>245</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>$(P)$(R)CH7:Current_RBV</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH7:Current_RBV.VAL</string>
+    </property>
+    <property name="foreground">
+     <color>
+      <red>0</red>
+      <green>0</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="background">
+     <color>
+      <red>196</red>
+      <green>196</green>
+      <blue>196</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+    <property name="precisionMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="limitsMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="maxValue">
+     <double>1.000000000000000</double>
+    </property>
+    <property name="minValue">
+     <double>0.000000000000000</double>
+    </property>
+    <property name="fontScaleMode" stdset="0">
+     <enum>caLineEdit::WidthAndHeight</enum>
+    </property>
+    <property name="formatType">
+     <enum>caLineEdit::decimal</enum>
+    </property>
+   </widget>
+   <widget class="caLineEdit" name="caLineEdit_25">
+    <property name="geometry">
+     <rect>
+      <x>780</x>
+      <y>245</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>$(P)$(R)CH5:Current_RBV</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH5:Current_RBV.VAL</string>
+    </property>
+    <property name="foreground">
+     <color>
+      <red>0</red>
+      <green>0</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="background">
+     <color>
+      <red>196</red>
+      <green>196</green>
+      <blue>196</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+    <property name="precisionMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="limitsMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="maxValue">
+     <double>1.000000000000000</double>
+    </property>
+    <property name="minValue">
+     <double>0.000000000000000</double>
+    </property>
+    <property name="fontScaleMode" stdset="0">
+     <enum>caLineEdit::WidthAndHeight</enum>
+    </property>
+    <property name="formatType">
+     <enum>caLineEdit::decimal</enum>
+    </property>
+   </widget>
+   <widget class="caLineEdit" name="caLineEdit_26">
+    <property name="geometry">
+     <rect>
+      <x>275</x>
+      <y>245</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="inputMask">
+     <string/>
+    </property>
+    <property name="text">
+     <string>$(P)$(R)CH1:Current_RBV</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH1:Current_RBV.VAL</string>
+    </property>
+    <property name="foreground">
+     <color>
+      <red>0</red>
+      <green>0</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="background">
+     <color>
+      <red>196</red>
+      <green>196</green>
+      <blue>196</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+    <property name="precisionMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="limitsMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="maxValue">
+     <double>1.000000000000000</double>
+    </property>
+    <property name="minValue">
+     <double>0.000000000000000</double>
+    </property>
+    <property name="fontScaleMode" stdset="0">
+     <enum>caLineEdit::WidthAndHeight</enum>
+    </property>
+    <property name="formatType">
+     <enum>caLineEdit::decimal</enum>
+    </property>
+   </widget>
+   <widget class="caLineEdit" name="caLineEdit_27">
+    <property name="geometry">
+     <rect>
+      <x>405</x>
+      <y>245</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>$(P)$(R)CH2:Current_RBV</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH2:Current_RBV.VAL</string>
+    </property>
+    <property name="foreground">
+     <color>
+      <red>0</red>
+      <green>0</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="background">
+     <color>
+      <red>196</red>
+      <green>196</green>
+      <blue>196</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+    <property name="precisionMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="limitsMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="maxValue">
+     <double>1.000000000000000</double>
+    </property>
+    <property name="minValue">
+     <double>0.000000000000000</double>
+    </property>
+    <property name="fontScaleMode" stdset="0">
+     <enum>caLineEdit::WidthAndHeight</enum>
+    </property>
+    <property name="formatType">
+     <enum>caLineEdit::decimal</enum>
+    </property>
+   </widget>
+   <widget class="caLineEdit" name="caLineEdit_28">
+    <property name="geometry">
+     <rect>
+      <x>655</x>
+      <y>245</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>$(P)$(R)CH4:Current_RBV</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH4:Current_RBV.VAL</string>
+    </property>
+    <property name="foreground">
+     <color>
+      <red>0</red>
+      <green>0</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="background">
+     <color>
+      <red>196</red>
+      <green>196</green>
+      <blue>196</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+    <property name="precisionMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="limitsMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="maxValue">
+     <double>1.000000000000000</double>
+    </property>
+    <property name="minValue">
+     <double>0.000000000000000</double>
+    </property>
+    <property name="fontScaleMode" stdset="0">
+     <enum>caLineEdit::WidthAndHeight</enum>
+    </property>
+    <property name="formatType">
+     <enum>caLineEdit::decimal</enum>
+    </property>
+   </widget>
+   <widget class="caLineEdit" name="caLineEdit_29">
+    <property name="geometry">
+     <rect>
+      <x>145</x>
+      <y>245</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="inputMask">
+     <string/>
+    </property>
+    <property name="text">
+     <string>$(P)$(R)CH0:Current_RBV</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH0:Current_RBV.VAL</string>
+    </property>
+    <property name="foreground">
+     <color>
+      <red>0</red>
+      <green>0</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="background">
+     <color>
+      <red>196</red>
+      <green>196</green>
+      <blue>196</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+    <property name="precisionMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="limitsMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="maxValue">
+     <double>1.000000000000000</double>
+    </property>
+    <property name="minValue">
+     <double>0.000000000000000</double>
+    </property>
+    <property name="fontScaleMode" stdset="0">
+     <enum>caLineEdit::WidthAndHeight</enum>
+    </property>
+    <property name="formatType">
+     <enum>caLineEdit::decimal</enum>
+    </property>
+   </widget>
+   <widget class="caMenu" name="caMenu_3">
+    <property name="geometry">
+     <rect>
+      <x>50</x>
+      <y>40</y>
+      <width>100</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)ReadAll.SCAN</string>
+    </property>
+    <property name="colorMode">
+     <enum>caMenu::Static</enum>
+    </property>
+    <property name="foreground">
+     <color>
+      <red>0</red>
+      <green>0</green>
+      <blue>0</blue>
+     </color>
+    </property>
+    <property name="background">
+     <color>
+      <red>115</red>
+      <green>223</green>
+      <blue>255</blue>
+     </color>
+    </property>
+   </widget>
+   <widget class="caMessageButton" name="caMessageButton_3">
+    <property name="geometry">
+     <rect>
+      <x>5</x>
+      <y>40</y>
+      <width>40</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>READ</string>
+    </property>
+    <property name="fontScaleMode">
+     <enum>EPushButton::WidthAndHeight</enum>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)ReadAll.PROC</string>
+    </property>
+    <property name="label">
+     <string notr="true">READ</string>
+    </property>
+    <property name="foreground">
+     <color>
+      <red>0</red>
+      <green>0</green>
+      <blue>0</blue>
+     </color>
+    </property>
+    <property name="background">
+     <color>
+      <red>115</red>
+      <green>223</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="releaseMessage">
+     <string>1</string>
+    </property>
+    <property name="colorMode">
+     <enum>caMessageButton::Static</enum>
+    </property>
+   </widget>
+   <widget class="QLabel" name="label_9">
+    <property name="geometry">
+     <rect>
+      <x>60</x>
+      <y>200</y>
+      <width>75</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Voltage:</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+    </property>
+   </widget>
+   <widget class="QLabel" name="label_10">
+    <property name="geometry">
+     <rect>
+      <x>60</x>
+      <y>245</y>
+      <width>75</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Current:</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+    </property>
+   </widget>
+   <widget class="caLineEdit" name="caLineEdit_30">
+    <property name="geometry">
+     <rect>
+      <x>1140</x>
+      <y>200</y>
+      <width>50</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>$(P)$(R)CH7:Voltage_RBV.EGU</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH7:Voltage_RBV.EGU</string>
+    </property>
+    <property name="foreground">
+     <color>
+      <red>0</red>
+      <green>0</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="background">
+     <color>
+      <red>196</red>
+      <green>196</green>
+      <blue>196</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+    <property name="precisionMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="limitsMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="maxValue">
+     <double>1.000000000000000</double>
+    </property>
+    <property name="minValue">
+     <double>0.000000000000000</double>
+    </property>
+    <property name="fontScaleMode" stdset="0">
+     <enum>caLineEdit::WidthAndHeight</enum>
+    </property>
+    <property name="formatType">
+     <enum>caLineEdit::decimal</enum>
+    </property>
+   </widget>
+   <widget class="caLineEdit" name="caLineEdit_31">
+    <property name="geometry">
+     <rect>
+      <x>1140</x>
+      <y>245</y>
+      <width>50</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>$(P)$(R)CH7:Current_RBV.EGU</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH7:Current_RBV.EGU</string>
+    </property>
+    <property name="foreground">
+     <color>
+      <red>0</red>
+      <green>0</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="background">
+     <color>
+      <red>196</red>
+      <green>196</green>
+      <blue>196</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+    <property name="precisionMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="limitsMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="maxValue">
+     <double>1.000000000000000</double>
+    </property>
+    <property name="minValue">
+     <double>0.000000000000000</double>
+    </property>
+    <property name="fontScaleMode" stdset="0">
+     <enum>caLineEdit::WidthAndHeight</enum>
+    </property>
+    <property name="formatType">
+     <enum>caLineEdit::decimal</enum>
+    </property>
+   </widget>
+   <widget class="caLabel" name="calabel">
+    <property name="geometry">
+     <rect>
+      <x>145</x>
+      <y>80</y>
+      <width>100</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="font">
+     <font>
+      <pointsize>11</pointsize>
+      <weight>75</weight>
+      <bold>true</bold>
+     </font>
+    </property>
+    <property name="text">
+     <string>0</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+    <property name="foreground">
+     <color>
+      <red>255</red>
+      <green>0</green>
+      <blue>0</blue>
+     </color>
+    </property>
+    <property name="visibility">
+     <enum>caLabel::IfNotZero</enum>
+    </property>
+    <property name="visibilityCalc">
+     <string notr="true"/>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH0:Power_RBV</string>
+    </property>
+   </widget>
+   <widget class="caLabel" name="calabel_2">
+    <property name="geometry">
+     <rect>
+      <x>145</x>
+      <y>80</y>
+      <width>100</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="font">
+     <font>
+      <pointsize>11</pointsize>
+      <weight>75</weight>
+      <bold>true</bold>
+     </font>
+    </property>
+    <property name="text">
+     <string>0</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+    <property name="foreground">
+     <color>
+      <red>0</red>
+      <green>0</green>
+      <blue>0</blue>
+     </color>
+    </property>
+    <property name="visibility">
+     <enum>caLabel::IfZero</enum>
+    </property>
+    <property name="visibilityCalc">
+     <string notr="true"/>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH0:Power_RBV</string>
+    </property>
+   </widget>
+   <widget class="caLabel" name="calabel_3">
+    <property name="geometry">
+     <rect>
+      <x>275</x>
+      <y>80</y>
+      <width>100</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="font">
+     <font>
+      <pointsize>11</pointsize>
+      <weight>75</weight>
+      <bold>true</bold>
+     </font>
+    </property>
+    <property name="text">
+     <string>1</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+    <property name="foreground">
+     <color>
+      <red>255</red>
+      <green>0</green>
+      <blue>0</blue>
+     </color>
+    </property>
+    <property name="visibility">
+     <enum>caLabel::IfNotZero</enum>
+    </property>
+    <property name="visibilityCalc">
+     <string notr="true"/>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH1:Power_RBV</string>
+    </property>
+   </widget>
+   <widget class="caLabel" name="calabel_4">
+    <property name="geometry">
+     <rect>
+      <x>275</x>
+      <y>80</y>
+      <width>100</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="font">
+     <font>
+      <pointsize>11</pointsize>
+      <weight>75</weight>
+      <bold>true</bold>
+     </font>
+    </property>
+    <property name="text">
+     <string>1</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+    <property name="foreground">
+     <color>
+      <red>0</red>
+      <green>0</green>
+      <blue>0</blue>
+     </color>
+    </property>
+    <property name="visibility">
+     <enum>caLabel::IfZero</enum>
+    </property>
+    <property name="visibilityCalc">
+     <string notr="true"/>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH1:Power_RBV</string>
+    </property>
+   </widget>
+   <widget class="caLabel" name="calabel_5">
+    <property name="geometry">
+     <rect>
+      <x>405</x>
+      <y>80</y>
+      <width>100</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="font">
+     <font>
+      <pointsize>11</pointsize>
+      <weight>75</weight>
+      <bold>true</bold>
+     </font>
+    </property>
+    <property name="text">
+     <string>2</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+    <property name="foreground">
+     <color>
+      <red>255</red>
+      <green>0</green>
+      <blue>0</blue>
+     </color>
+    </property>
+    <property name="visibility">
+     <enum>caLabel::IfNotZero</enum>
+    </property>
+    <property name="visibilityCalc">
+     <string notr="true"/>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH2:Power_RBV</string>
+    </property>
+   </widget>
+   <widget class="caLabel" name="calabel_6">
+    <property name="geometry">
+     <rect>
+      <x>405</x>
+      <y>80</y>
+      <width>100</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="font">
+     <font>
+      <pointsize>11</pointsize>
+      <weight>75</weight>
+      <bold>true</bold>
+     </font>
+    </property>
+    <property name="text">
+     <string>2</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+    <property name="foreground">
+     <color>
+      <red>0</red>
+      <green>0</green>
+      <blue>0</blue>
+     </color>
+    </property>
+    <property name="visibility">
+     <enum>caLabel::IfZero</enum>
+    </property>
+    <property name="visibilityCalc">
+     <string notr="true"/>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH2:Power_RBV</string>
+    </property>
+   </widget>
+   <widget class="caLabel" name="calabel_7">
+    <property name="geometry">
+     <rect>
+      <x>530</x>
+      <y>80</y>
+      <width>100</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="font">
+     <font>
+      <pointsize>11</pointsize>
+      <weight>75</weight>
+      <bold>true</bold>
+     </font>
+    </property>
+    <property name="text">
+     <string>3</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+    <property name="foreground">
+     <color>
+      <red>255</red>
+      <green>0</green>
+      <blue>0</blue>
+     </color>
+    </property>
+    <property name="visibility">
+     <enum>caLabel::IfNotZero</enum>
+    </property>
+    <property name="visibilityCalc">
+     <string notr="true"/>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH3:Power_RBV</string>
+    </property>
+   </widget>
+   <widget class="caLabel" name="calabel_8">
+    <property name="geometry">
+     <rect>
+      <x>530</x>
+      <y>80</y>
+      <width>100</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="font">
+     <font>
+      <pointsize>11</pointsize>
+      <weight>75</weight>
+      <bold>true</bold>
+     </font>
+    </property>
+    <property name="text">
+     <string>3</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+    <property name="foreground">
+     <color>
+      <red>0</red>
+      <green>0</green>
+      <blue>0</blue>
+     </color>
+    </property>
+    <property name="visibility">
+     <enum>caLabel::IfZero</enum>
+    </property>
+    <property name="visibilityCalc">
+     <string notr="true"/>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH3:Power_RBV</string>
+    </property>
+   </widget>
+   <widget class="caLabel" name="calabel_9">
+    <property name="geometry">
+     <rect>
+      <x>655</x>
+      <y>80</y>
+      <width>100</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="font">
+     <font>
+      <pointsize>11</pointsize>
+      <weight>75</weight>
+      <bold>true</bold>
+     </font>
+    </property>
+    <property name="text">
+     <string>4</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+    <property name="foreground">
+     <color>
+      <red>255</red>
+      <green>0</green>
+      <blue>0</blue>
+     </color>
+    </property>
+    <property name="visibility">
+     <enum>caLabel::IfNotZero</enum>
+    </property>
+    <property name="visibilityCalc">
+     <string notr="true"/>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH4:Power_RBV</string>
+    </property>
+   </widget>
+   <widget class="caLabel" name="calabel_10">
+    <property name="geometry">
+     <rect>
+      <x>655</x>
+      <y>80</y>
+      <width>100</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="font">
+     <font>
+      <pointsize>11</pointsize>
+      <weight>75</weight>
+      <bold>true</bold>
+     </font>
+    </property>
+    <property name="text">
+     <string>4</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+    <property name="foreground">
+     <color>
+      <red>0</red>
+      <green>0</green>
+      <blue>0</blue>
+     </color>
+    </property>
+    <property name="visibility">
+     <enum>caLabel::IfZero</enum>
+    </property>
+    <property name="visibilityCalc">
+     <string notr="true"/>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH4:Power_RBV</string>
+    </property>
+   </widget>
+   <widget class="caLabel" name="calabel_11">
+    <property name="geometry">
+     <rect>
+      <x>780</x>
+      <y>80</y>
+      <width>100</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="font">
+     <font>
+      <pointsize>11</pointsize>
+      <weight>75</weight>
+      <bold>true</bold>
+     </font>
+    </property>
+    <property name="text">
+     <string>5</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+    <property name="foreground">
+     <color>
+      <red>255</red>
+      <green>0</green>
+      <blue>0</blue>
+     </color>
+    </property>
+    <property name="visibility">
+     <enum>caLabel::IfNotZero</enum>
+    </property>
+    <property name="visibilityCalc">
+     <string notr="true"/>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH5:Power_RBV</string>
+    </property>
+   </widget>
+   <widget class="caLabel" name="calabel_12">
+    <property name="geometry">
+     <rect>
+      <x>780</x>
+      <y>80</y>
+      <width>100</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="font">
+     <font>
+      <pointsize>11</pointsize>
+      <weight>75</weight>
+      <bold>true</bold>
+     </font>
+    </property>
+    <property name="text">
+     <string>5</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+    <property name="foreground">
+     <color>
+      <red>0</red>
+      <green>0</green>
+      <blue>0</blue>
+     </color>
+    </property>
+    <property name="visibility">
+     <enum>caLabel::IfZero</enum>
+    </property>
+    <property name="visibilityCalc">
+     <string notr="true"/>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH5:Power_RBV</string>
+    </property>
+   </widget>
+   <widget class="caLabel" name="calabel_13">
+    <property name="geometry">
+     <rect>
+      <x>905</x>
+      <y>80</y>
+      <width>100</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="font">
+     <font>
+      <pointsize>11</pointsize>
+      <weight>75</weight>
+      <bold>true</bold>
+     </font>
+    </property>
+    <property name="text">
+     <string>6</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+    <property name="foreground">
+     <color>
+      <red>255</red>
+      <green>0</green>
+      <blue>0</blue>
+     </color>
+    </property>
+    <property name="visibility">
+     <enum>caLabel::IfNotZero</enum>
+    </property>
+    <property name="visibilityCalc">
+     <string notr="true"/>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH6:Power_RBV</string>
+    </property>
+   </widget>
+   <widget class="caLabel" name="calabel_14">
+    <property name="geometry">
+     <rect>
+      <x>905</x>
+      <y>80</y>
+      <width>100</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="font">
+     <font>
+      <pointsize>11</pointsize>
+      <weight>75</weight>
+      <bold>true</bold>
+     </font>
+    </property>
+    <property name="text">
+     <string>6</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+    <property name="foreground">
+     <color>
+      <red>0</red>
+      <green>0</green>
+      <blue>0</blue>
+     </color>
+    </property>
+    <property name="visibility">
+     <enum>caLabel::IfZero</enum>
+    </property>
+    <property name="visibilityCalc">
+     <string notr="true"/>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH6:Power_RBV</string>
+    </property>
+   </widget>
+   <widget class="caLabel" name="calabel_15">
+    <property name="geometry">
+     <rect>
+      <x>1030</x>
+      <y>80</y>
+      <width>100</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="font">
+     <font>
+      <pointsize>11</pointsize>
+      <weight>75</weight>
+      <bold>true</bold>
+     </font>
+    </property>
+    <property name="text">
+     <string>7</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+    <property name="foreground">
+     <color>
+      <red>255</red>
+      <green>0</green>
+      <blue>0</blue>
+     </color>
+    </property>
+    <property name="visibility">
+     <enum>caLabel::IfNotZero</enum>
+    </property>
+    <property name="visibilityCalc">
+     <string notr="true"/>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH7:Power_RBV</string>
+    </property>
+   </widget>
+   <widget class="caLabel" name="calabel_16">
+    <property name="geometry">
+     <rect>
+      <x>1030</x>
+      <y>80</y>
+      <width>100</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="font">
+     <font>
+      <pointsize>11</pointsize>
+      <weight>75</weight>
+      <bold>true</bold>
+     </font>
+    </property>
+    <property name="text">
+     <string>7</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+    <property name="foreground">
+     <color>
+      <red>0</red>
+      <green>0</green>
+      <blue>0</blue>
+     </color>
+    </property>
+    <property name="visibility">
+     <enum>caLabel::IfZero</enum>
+    </property>
+    <property name="visibilityCalc">
+     <string notr="true"/>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH7:Power_RBV</string>
+    </property>
+   </widget>
+   <widget class="caChoice" name="cachoice">
+    <property name="geometry">
+     <rect>
+      <x>655</x>
+      <y>145</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH4:Power</string>
+    </property>
+    <property name="stackingMode" stdset="0">
+     <enum>caChoice::Column</enum>
+    </property>
+    <property name="endBit">
+     <number>1</number>
+    </property>
+   </widget>
+   <widget class="caChoice" name="cachoice_2">
+    <property name="geometry">
+     <rect>
+      <x>530</x>
+      <y>145</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH3:Power</string>
+    </property>
+    <property name="stackingMode" stdset="0">
+     <enum>caChoice::Column</enum>
+    </property>
+    <property name="endBit">
+     <number>1</number>
+    </property>
+   </widget>
+   <widget class="caChoice" name="cachoice_3">
+    <property name="geometry">
+     <rect>
+      <x>405</x>
+      <y>145</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH2:Power</string>
+    </property>
+    <property name="stackingMode" stdset="0">
+     <enum>caChoice::Column</enum>
+    </property>
+    <property name="endBit">
+     <number>1</number>
+    </property>
+   </widget>
+   <widget class="caChoice" name="cachoice_4">
+    <property name="geometry">
+     <rect>
+      <x>275</x>
+      <y>145</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH1:Power</string>
+    </property>
+    <property name="stackingMode" stdset="0">
+     <enum>caChoice::Column</enum>
+    </property>
+    <property name="endBit">
+     <number>1</number>
+    </property>
+   </widget>
+   <widget class="caChoice" name="cachoice_5">
+    <property name="geometry">
+     <rect>
+      <x>145</x>
+      <y>145</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH0:Power</string>
+    </property>
+    <property name="stackingMode" stdset="0">
+     <enum>caChoice::Column</enum>
+    </property>
+    <property name="endBit">
+     <number>1</number>
+    </property>
+   </widget>
+   <widget class="caChoice" name="cachoice_6">
+    <property name="geometry">
+     <rect>
+      <x>780</x>
+      <y>145</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH5:Power</string>
+    </property>
+    <property name="stackingMode" stdset="0">
+     <enum>caChoice::Column</enum>
+    </property>
+    <property name="endBit">
+     <number>1</number>
+    </property>
+   </widget>
+   <widget class="caChoice" name="cachoice_7">
+    <property name="geometry">
+     <rect>
+      <x>905</x>
+      <y>145</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH6:Power</string>
+    </property>
+    <property name="stackingMode" stdset="0">
+     <enum>caChoice::Column</enum>
+    </property>
+    <property name="endBit">
+     <number>1</number>
+    </property>
+   </widget>
+   <widget class="caChoice" name="cachoice_8">
+    <property name="geometry">
+     <rect>
+      <x>1030</x>
+      <y>145</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH7:Power</string>
+    </property>
+    <property name="stackingMode" stdset="0">
+     <enum>caChoice::Column</enum>
+    </property>
+    <property name="endBit">
+     <number>1</number>
+    </property>
+   </widget>
+   <widget class="caTextEntry" name="catextentry_27">
+    <property name="geometry">
+     <rect>
+      <x>1030</x>
+      <y>305</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH7:RampUpRate.VAL</string>
+    </property>
+    <property name="background">
+     <color>
+      <red>115</red>
+      <green>223</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+   </widget>
+   <widget class="caTextEntry" name="catextentry_22">
+    <property name="geometry">
+     <rect>
+      <x>905</x>
+      <y>305</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH6:RampUpRate.VAL</string>
+    </property>
+    <property name="background">
+     <color>
+      <red>115</red>
+      <green>223</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+   </widget>
+   <widget class="caTextEntry" name="catextentry_25">
+    <property name="geometry">
+     <rect>
+      <x>146</x>
+      <y>305</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH0:RampUpRate.VAL</string>
+    </property>
+    <property name="background">
+     <color>
+      <red>115</red>
+      <green>223</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+   </widget>
+   <widget class="caTextEntry" name="catextentry_21">
+    <property name="geometry">
+     <rect>
+      <x>780</x>
+      <y>305</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH5:RampUpRate.VAL</string>
+    </property>
+    <property name="background">
+     <color>
+      <red>115</red>
+      <green>223</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+   </widget>
+   <widget class="caTextEntry" name="catextentry_24">
+    <property name="geometry">
+     <rect>
+      <x>275</x>
+      <y>305</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH1:RampUpRate.VAL</string>
+    </property>
+    <property name="background">
+     <color>
+      <red>115</red>
+      <green>223</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+   </widget>
+   <widget class="caTextEntry" name="catextentry_20">
+    <property name="geometry">
+     <rect>
+      <x>655</x>
+      <y>305</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH4:RampUpRate.VAL</string>
+    </property>
+    <property name="background">
+     <color>
+      <red>115</red>
+      <green>223</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+   </widget>
+   <widget class="caTextEntry" name="catextentry_23">
+    <property name="geometry">
+     <rect>
+      <x>405</x>
+      <y>305</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH2:RampUpRate.VAL</string>
+    </property>
+    <property name="background">
+     <color>
+      <red>115</red>
+      <green>223</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+   </widget>
+   <widget class="caTextEntry" name="catextentry_26">
+    <property name="geometry">
+     <rect>
+      <x>530</x>
+      <y>305</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH3:RampUpRate.VAL</string>
+    </property>
+    <property name="background">
+     <color>
+      <red>115</red>
+      <green>223</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+   </widget>
+   <widget class="caTextEntry" name="catextentry_28">
+    <property name="geometry">
+     <rect>
+      <x>905</x>
+      <y>360</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH6:RampDownRate.VAL</string>
+    </property>
+    <property name="background">
+     <color>
+      <red>115</red>
+      <green>223</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+   </widget>
+   <widget class="caTextEntry" name="catextentry_29">
+    <property name="geometry">
+     <rect>
+      <x>780</x>
+      <y>360</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH5:RampDownRate.VAL</string>
+    </property>
+    <property name="background">
+     <color>
+      <red>115</red>
+      <green>223</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+   </widget>
+   <widget class="caTextEntry" name="catextentry_30">
+    <property name="geometry">
+     <rect>
+      <x>275</x>
+      <y>360</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH1:RampDownRate.VAL</string>
+    </property>
+    <property name="background">
+     <color>
+      <red>115</red>
+      <green>223</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+   </widget>
+   <widget class="caTextEntry" name="catextentry_31">
+    <property name="geometry">
+     <rect>
+      <x>405</x>
+      <y>360</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH2:RampDownRate.VAL</string>
+    </property>
+    <property name="background">
+     <color>
+      <red>115</red>
+      <green>223</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+   </widget>
+   <widget class="caTextEntry" name="catextentry_32">
+    <property name="geometry">
+     <rect>
+      <x>146</x>
+      <y>360</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH0:RampDownRate.VAL</string>
+    </property>
+    <property name="background">
+     <color>
+      <red>115</red>
+      <green>223</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+   </widget>
+   <widget class="caTextEntry" name="catextentry_33">
+    <property name="geometry">
+     <rect>
+      <x>530</x>
+      <y>360</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH3:RampDownRate.VAL</string>
+    </property>
+    <property name="background">
+     <color>
+      <red>115</red>
+      <green>223</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+   </widget>
+   <widget class="caTextEntry" name="catextentry_34">
+    <property name="geometry">
+     <rect>
+      <x>1030</x>
+      <y>360</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH7:RampDownRate.VAL</string>
+    </property>
+    <property name="background">
+     <color>
+      <red>115</red>
+      <green>223</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+   </widget>
+   <widget class="caTextEntry" name="catextentry_35">
+    <property name="geometry">
+     <rect>
+      <x>655</x>
+      <y>360</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH4:RampDownRate.VAL</string>
+    </property>
+    <property name="background">
+     <color>
+      <red>115</red>
+      <green>223</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+   </widget>
+   <widget class="QLabel" name="label_11">
+    <property name="geometry">
+     <rect>
+      <x>40</x>
+      <y>305</y>
+      <width>96</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Ramp up rate:</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+    </property>
+   </widget>
+   <widget class="QLabel" name="label_12">
+    <property name="geometry">
+     <rect>
+      <x>20</x>
+      <y>360</y>
+      <width>116</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Ramp down rate:</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+    </property>
+   </widget>
+   <widget class="caLineEdit" name="caLineEdit_32">
+    <property name="geometry">
+     <rect>
+      <x>1140</x>
+      <y>305</y>
+      <width>50</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>$(P)$(R)CH7:RampUpRate.EGU</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH7:RampUpRate.EGU</string>
+    </property>
+    <property name="foreground">
+     <color>
+      <red>0</red>
+      <green>0</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="background">
+     <color>
+      <red>196</red>
+      <green>196</green>
+      <blue>196</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+    <property name="precisionMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="limitsMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="maxValue">
+     <double>1.000000000000000</double>
+    </property>
+    <property name="minValue">
+     <double>0.000000000000000</double>
+    </property>
+    <property name="fontScaleMode" stdset="0">
+     <enum>caLineEdit::WidthAndHeight</enum>
+    </property>
+    <property name="formatType">
+     <enum>caLineEdit::decimal</enum>
+    </property>
+   </widget>
+   <widget class="caLineEdit" name="caLineEdit_33">
+    <property name="geometry">
+     <rect>
+      <x>1140</x>
+      <y>360</y>
+      <width>50</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>$(P)$(R)CH7:RampDownRate.EGU</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH7:RampDownRate.EGU</string>
+    </property>
+    <property name="foreground">
+     <color>
+      <red>0</red>
+      <green>0</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="background">
+     <color>
+      <red>196</red>
+      <green>196</green>
+      <blue>196</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+    <property name="precisionMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="limitsMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="maxValue">
+     <double>1.000000000000000</double>
+    </property>
+    <property name="minValue">
+     <double>0.000000000000000</double>
+    </property>
+    <property name="fontScaleMode" stdset="0">
+     <enum>caLineEdit::WidthAndHeight</enum>
+    </property>
+    <property name="formatType">
+     <enum>caLineEdit::decimal</enum>
+    </property>
+   </widget>
+   <widget class="caLineEdit" name="caLineEdit_34">
+    <property name="geometry">
+     <rect>
+      <x>530</x>
+      <y>340</y>
+      <width>100</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>$(P)$(R)CH3:RampDownRate_RBV</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH3:RampDownRate_RBV.VAL</string>
+    </property>
+    <property name="foreground">
+     <color>
+      <red>0</red>
+      <green>0</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="background">
+     <color>
+      <red>196</red>
+      <green>196</green>
+      <blue>196</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+    <property name="precisionMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="limitsMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="maxValue">
+     <double>1.000000000000000</double>
+    </property>
+    <property name="minValue">
+     <double>0.000000000000000</double>
+    </property>
+    <property name="fontScaleMode" stdset="0">
+     <enum>caLineEdit::WidthAndHeight</enum>
+    </property>
+    <property name="formatType">
+     <enum>caLineEdit::decimal</enum>
+    </property>
+   </widget>
+   <widget class="caLineEdit" name="caLineEdit_35">
+    <property name="geometry">
+     <rect>
+      <x>1030</x>
+      <y>285</y>
+      <width>100</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>$(P)$(R)CH7:RampUpRate_RBV</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH7:RampUpRate_RBV.VAL</string>
+    </property>
+    <property name="foreground">
+     <color>
+      <red>0</red>
+      <green>0</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="background">
+     <color>
+      <red>196</red>
+      <green>196</green>
+      <blue>196</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+    <property name="precisionMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="limitsMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="maxValue">
+     <double>1.000000000000000</double>
+    </property>
+    <property name="minValue">
+     <double>0.000000000000000</double>
+    </property>
+    <property name="fontScaleMode" stdset="0">
+     <enum>caLineEdit::WidthAndHeight</enum>
+    </property>
+    <property name="formatType">
+     <enum>caLineEdit::decimal</enum>
+    </property>
+   </widget>
+   <widget class="caLineEdit" name="caLineEdit_36">
+    <property name="geometry">
+     <rect>
+      <x>905</x>
+      <y>340</y>
+      <width>100</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>$(P)$(R)CH6:RampDownRate_RBV.VAL</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH6:RampDownRate_RBV.VAL</string>
+    </property>
+    <property name="foreground">
+     <color>
+      <red>0</red>
+      <green>0</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="background">
+     <color>
+      <red>196</red>
+      <green>196</green>
+      <blue>196</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+    <property name="precisionMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="limitsMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="maxValue">
+     <double>1.000000000000000</double>
+    </property>
+    <property name="minValue">
+     <double>0.000000000000000</double>
+    </property>
+    <property name="fontScaleMode" stdset="0">
+     <enum>caLineEdit::WidthAndHeight</enum>
+    </property>
+    <property name="formatType">
+     <enum>caLineEdit::decimal</enum>
+    </property>
+   </widget>
+   <widget class="caLineEdit" name="caLineEdit_37">
+    <property name="geometry">
+     <rect>
+      <x>275</x>
+      <y>285</y>
+      <width>100</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="inputMask">
+     <string/>
+    </property>
+    <property name="text">
+     <string>$(P)$(R)CH1:RampUpRate_RBV</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH1:RampUpRate_RBV.VAL</string>
+    </property>
+    <property name="foreground">
+     <color>
+      <red>0</red>
+      <green>0</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="background">
+     <color>
+      <red>196</red>
+      <green>196</green>
+      <blue>196</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+    <property name="precisionMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="limitsMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="maxValue">
+     <double>1.000000000000000</double>
+    </property>
+    <property name="minValue">
+     <double>0.000000000000000</double>
+    </property>
+    <property name="fontScaleMode" stdset="0">
+     <enum>caLineEdit::WidthAndHeight</enum>
+    </property>
+    <property name="formatType">
+     <enum>caLineEdit::decimal</enum>
+    </property>
+   </widget>
+   <widget class="caLineEdit" name="caLineEdit_38">
+    <property name="geometry">
+     <rect>
+      <x>145</x>
+      <y>285</y>
+      <width>100</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="inputMask">
+     <string/>
+    </property>
+    <property name="text">
+     <string>$(P)$(R)CH0:RampUpRate_RBV</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH0:RampUpRate_RBV.VAL</string>
+    </property>
+    <property name="foreground">
+     <color>
+      <red>0</red>
+      <green>0</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="background">
+     <color>
+      <red>196</red>
+      <green>196</green>
+      <blue>196</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+    <property name="precisionMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="limitsMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="maxValue">
+     <double>1.000000000000000</double>
+    </property>
+    <property name="minValue">
+     <double>0.000000000000000</double>
+    </property>
+    <property name="fontScaleMode" stdset="0">
+     <enum>caLineEdit::WidthAndHeight</enum>
+    </property>
+    <property name="formatType">
+     <enum>caLineEdit::decimal</enum>
+    </property>
+   </widget>
+   <widget class="caLineEdit" name="caLineEdit_39">
+    <property name="geometry">
+     <rect>
+      <x>655</x>
+      <y>285</y>
+      <width>100</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>$(P)$(R)CH4:RampUpRate_RBV</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH4:RampUpRate_RBV.VAL</string>
+    </property>
+    <property name="foreground">
+     <color>
+      <red>0</red>
+      <green>0</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="background">
+     <color>
+      <red>196</red>
+      <green>196</green>
+      <blue>196</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+    <property name="precisionMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="limitsMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="maxValue">
+     <double>1.000000000000000</double>
+    </property>
+    <property name="minValue">
+     <double>0.000000000000000</double>
+    </property>
+    <property name="fontScaleMode" stdset="0">
+     <enum>caLineEdit::WidthAndHeight</enum>
+    </property>
+    <property name="formatType">
+     <enum>caLineEdit::decimal</enum>
+    </property>
+   </widget>
+   <widget class="caLineEdit" name="caLineEdit_40">
+    <property name="geometry">
+     <rect>
+      <x>780</x>
+      <y>340</y>
+      <width>100</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>$(P)$(R)CH5:RampDownRate_RBV</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH5:RampDownRate_RBV.VAL</string>
+    </property>
+    <property name="foreground">
+     <color>
+      <red>0</red>
+      <green>0</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="background">
+     <color>
+      <red>196</red>
+      <green>196</green>
+      <blue>196</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+    <property name="precisionMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="limitsMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="maxValue">
+     <double>1.000000000000000</double>
+    </property>
+    <property name="minValue">
+     <double>0.000000000000000</double>
+    </property>
+    <property name="fontScaleMode" stdset="0">
+     <enum>caLineEdit::WidthAndHeight</enum>
+    </property>
+    <property name="formatType">
+     <enum>caLineEdit::decimal</enum>
+    </property>
+   </widget>
+   <widget class="caLineEdit" name="caLineEdit_41">
+    <property name="geometry">
+     <rect>
+      <x>780</x>
+      <y>285</y>
+      <width>100</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>$(P)$(R)CH5:RampUpRate_RBV</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH5:RampUpRate_RBV.VAL</string>
+    </property>
+    <property name="foreground">
+     <color>
+      <red>0</red>
+      <green>0</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="background">
+     <color>
+      <red>196</red>
+      <green>196</green>
+      <blue>196</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+    <property name="precisionMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="limitsMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="maxValue">
+     <double>1.000000000000000</double>
+    </property>
+    <property name="minValue">
+     <double>0.000000000000000</double>
+    </property>
+    <property name="fontScaleMode" stdset="0">
+     <enum>caLineEdit::WidthAndHeight</enum>
+    </property>
+    <property name="formatType">
+     <enum>caLineEdit::decimal</enum>
+    </property>
+   </widget>
+   <widget class="caLineEdit" name="caLineEdit_42">
+    <property name="geometry">
+     <rect>
+      <x>530</x>
+      <y>285</y>
+      <width>100</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>$(P)$(R)CH3:RampUpRate_RBV</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH3:RampUpRate_RBV.VAL</string>
+    </property>
+    <property name="foreground">
+     <color>
+      <red>0</red>
+      <green>0</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="background">
+     <color>
+      <red>196</red>
+      <green>196</green>
+      <blue>196</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+    <property name="precisionMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="limitsMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="maxValue">
+     <double>1.000000000000000</double>
+    </property>
+    <property name="minValue">
+     <double>0.000000000000000</double>
+    </property>
+    <property name="fontScaleMode" stdset="0">
+     <enum>caLineEdit::WidthAndHeight</enum>
+    </property>
+    <property name="formatType">
+     <enum>caLineEdit::decimal</enum>
+    </property>
+   </widget>
+   <widget class="caLineEdit" name="caLineEdit_43">
+    <property name="geometry">
+     <rect>
+      <x>905</x>
+      <y>285</y>
+      <width>100</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>$(P)$(R)CH6:RampUpRate_RBV</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH6:RampUpRate_RBV.VAL</string>
+    </property>
+    <property name="foreground">
+     <color>
+      <red>0</red>
+      <green>0</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="background">
+     <color>
+      <red>196</red>
+      <green>196</green>
+      <blue>196</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+    <property name="precisionMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="limitsMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="maxValue">
+     <double>1.000000000000000</double>
+    </property>
+    <property name="minValue">
+     <double>0.000000000000000</double>
+    </property>
+    <property name="fontScaleMode" stdset="0">
+     <enum>caLineEdit::WidthAndHeight</enum>
+    </property>
+    <property name="formatType">
+     <enum>caLineEdit::decimal</enum>
+    </property>
+   </widget>
+   <widget class="caLineEdit" name="caLineEdit_44">
+    <property name="geometry">
+     <rect>
+      <x>405</x>
+      <y>340</y>
+      <width>100</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>$(P)$(R)CH2:RampDownRate_RBV</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH2:RampDownRate_RBV.VAL</string>
+    </property>
+    <property name="foreground">
+     <color>
+      <red>0</red>
+      <green>0</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="background">
+     <color>
+      <red>196</red>
+      <green>196</green>
+      <blue>196</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+    <property name="precisionMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="limitsMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="maxValue">
+     <double>1.000000000000000</double>
+    </property>
+    <property name="minValue">
+     <double>0.000000000000000</double>
+    </property>
+    <property name="fontScaleMode" stdset="0">
+     <enum>caLineEdit::WidthAndHeight</enum>
+    </property>
+    <property name="formatType">
+     <enum>caLineEdit::decimal</enum>
+    </property>
+   </widget>
+   <widget class="caLineEdit" name="caLineEdit_45">
+    <property name="geometry">
+     <rect>
+      <x>145</x>
+      <y>340</y>
+      <width>100</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="inputMask">
+     <string/>
+    </property>
+    <property name="text">
+     <string>$(P)$(R)CH0:RampDownRate_RBV</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH0:RampDownRate_RBV.VAL</string>
+    </property>
+    <property name="foreground">
+     <color>
+      <red>0</red>
+      <green>0</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="background">
+     <color>
+      <red>196</red>
+      <green>196</green>
+      <blue>196</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+    <property name="precisionMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="limitsMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="maxValue">
+     <double>1.000000000000000</double>
+    </property>
+    <property name="minValue">
+     <double>0.000000000000000</double>
+    </property>
+    <property name="fontScaleMode" stdset="0">
+     <enum>caLineEdit::WidthAndHeight</enum>
+    </property>
+    <property name="formatType">
+     <enum>caLineEdit::decimal</enum>
+    </property>
+   </widget>
+   <widget class="caLineEdit" name="caLineEdit_46">
+    <property name="geometry">
+     <rect>
+      <x>275</x>
+      <y>340</y>
+      <width>100</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="inputMask">
+     <string/>
+    </property>
+    <property name="text">
+     <string>$(P)$(R)CH1:RampDownRate_RBV</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH1:RampDownRate_RBV.VAL</string>
+    </property>
+    <property name="foreground">
+     <color>
+      <red>0</red>
+      <green>0</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="background">
+     <color>
+      <red>196</red>
+      <green>196</green>
+      <blue>196</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+    <property name="precisionMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="limitsMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="maxValue">
+     <double>1.000000000000000</double>
+    </property>
+    <property name="minValue">
+     <double>0.000000000000000</double>
+    </property>
+    <property name="fontScaleMode" stdset="0">
+     <enum>caLineEdit::WidthAndHeight</enum>
+    </property>
+    <property name="formatType">
+     <enum>caLineEdit::decimal</enum>
+    </property>
+   </widget>
+   <widget class="caLineEdit" name="caLineEdit_47">
+    <property name="geometry">
+     <rect>
+      <x>1030</x>
+      <y>340</y>
+      <width>100</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>$(P)$(R)CH7:RampDownRate_RBV</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH7:RampDownRate_RBV.VAL</string>
+    </property>
+    <property name="foreground">
+     <color>
+      <red>0</red>
+      <green>0</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="background">
+     <color>
+      <red>196</red>
+      <green>196</green>
+      <blue>196</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+    <property name="precisionMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="limitsMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="maxValue">
+     <double>1.000000000000000</double>
+    </property>
+    <property name="minValue">
+     <double>0.000000000000000</double>
+    </property>
+    <property name="fontScaleMode" stdset="0">
+     <enum>caLineEdit::WidthAndHeight</enum>
+    </property>
+    <property name="formatType">
+     <enum>caLineEdit::decimal</enum>
+    </property>
+   </widget>
+   <widget class="caLineEdit" name="caLineEdit_48">
+    <property name="geometry">
+     <rect>
+      <x>405</x>
+      <y>285</y>
+      <width>100</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>$(P)$(R)CH2:RampUpRate_RBV</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH2:RampUpRate_RBV.VAL</string>
+    </property>
+    <property name="foreground">
+     <color>
+      <red>0</red>
+      <green>0</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="background">
+     <color>
+      <red>196</red>
+      <green>196</green>
+      <blue>196</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+    <property name="precisionMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="limitsMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="maxValue">
+     <double>1.000000000000000</double>
+    </property>
+    <property name="minValue">
+     <double>0.000000000000000</double>
+    </property>
+    <property name="fontScaleMode" stdset="0">
+     <enum>caLineEdit::WidthAndHeight</enum>
+    </property>
+    <property name="formatType">
+     <enum>caLineEdit::decimal</enum>
+    </property>
+   </widget>
+   <widget class="caLineEdit" name="caLineEdit_49">
+    <property name="geometry">
+     <rect>
+      <x>655</x>
+      <y>340</y>
+      <width>100</width>
+      <height>20</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>$(P)$(R)CH4:RampDownRate_RBV</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH4:RampDownRate_RBV.VAL</string>
+    </property>
+    <property name="foreground">
+     <color>
+      <red>0</red>
+      <green>0</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="background">
+     <color>
+      <red>196</red>
+      <green>196</green>
+      <blue>196</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+    <property name="precisionMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="limitsMode">
+     <enum>caLineEdit::Channel</enum>
+    </property>
+    <property name="maxValue">
+     <double>1.000000000000000</double>
+    </property>
+    <property name="minValue">
+     <double>0.000000000000000</double>
+    </property>
+    <property name="fontScaleMode" stdset="0">
+     <enum>caLineEdit::WidthAndHeight</enum>
+    </property>
+    <property name="formatType">
+     <enum>caLineEdit::decimal</enum>
+    </property>
+   </widget>
+   <widget class="caChoice" name="cachoice_9">
+    <property name="geometry">
+     <rect>
+      <x>530</x>
+      <y>410</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH3:PowerDownMode</string>
+    </property>
+    <property name="stackingMode" stdset="0">
+     <enum>caChoice::Column</enum>
+    </property>
+    <property name="endBit">
+     <number>1</number>
+    </property>
+   </widget>
+   <widget class="caChoice" name="cachoice_10">
+    <property name="geometry">
+     <rect>
+      <x>655</x>
+      <y>410</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH4:PowerDownMode</string>
+    </property>
+    <property name="stackingMode" stdset="0">
+     <enum>caChoice::Column</enum>
+    </property>
+    <property name="endBit">
+     <number>1</number>
+    </property>
+   </widget>
+   <widget class="caChoice" name="cachoice_11">
+    <property name="geometry">
+     <rect>
+      <x>145</x>
+      <y>410</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH0:PowerDownMode</string>
+    </property>
+    <property name="stackingMode" stdset="0">
+     <enum>caChoice::Column</enum>
+    </property>
+    <property name="endBit">
+     <number>1</number>
+    </property>
+   </widget>
+   <widget class="caChoice" name="cachoice_12">
+    <property name="geometry">
+     <rect>
+      <x>275</x>
+      <y>410</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH1:PowerDownMode</string>
+    </property>
+    <property name="stackingMode" stdset="0">
+     <enum>caChoice::Column</enum>
+    </property>
+    <property name="endBit">
+     <number>1</number>
+    </property>
+   </widget>
+   <widget class="caChoice" name="cachoice_13">
+    <property name="geometry">
+     <rect>
+      <x>1030</x>
+      <y>410</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH7:PowerDownMode</string>
+    </property>
+    <property name="stackingMode" stdset="0">
+     <enum>caChoice::Column</enum>
+    </property>
+    <property name="endBit">
+     <number>1</number>
+    </property>
+   </widget>
+   <widget class="caChoice" name="cachoice_14">
+    <property name="geometry">
+     <rect>
+      <x>405</x>
+      <y>410</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH2:PowerDownMode</string>
+    </property>
+    <property name="stackingMode" stdset="0">
+     <enum>caChoice::Column</enum>
+    </property>
+    <property name="endBit">
+     <number>1</number>
+    </property>
+   </widget>
+   <widget class="caChoice" name="cachoice_15">
+    <property name="geometry">
+     <rect>
+      <x>905</x>
+      <y>410</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH6:PowerDownMode</string>
+    </property>
+    <property name="stackingMode" stdset="0">
+     <enum>caChoice::Column</enum>
+    </property>
+    <property name="endBit">
+     <number>1</number>
+    </property>
+   </widget>
+   <widget class="caChoice" name="cachoice_16">
+    <property name="geometry">
+     <rect>
+      <x>780</x>
+      <y>410</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH5:PowerDownMode</string>
+    </property>
+    <property name="stackingMode" stdset="0">
+     <enum>caChoice::Column</enum>
+    </property>
+    <property name="endBit">
+     <number>1</number>
+    </property>
+   </widget>
+   <widget class="QLabel" name="label_13">
+    <property name="geometry">
+     <rect>
+      <x>5</x>
+      <y>410</y>
+      <width>131</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Power down mode:</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+    </property>
+   </widget>
+   <widget class="caChoice" name="cachoice_17">
+    <property name="geometry">
+     <rect>
+      <x>905</x>
+      <y>445</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH6:IMonRange</string>
+    </property>
+    <property name="stackingMode" stdset="0">
+     <enum>caChoice::Column</enum>
+    </property>
+    <property name="endBit">
+     <number>1</number>
+    </property>
+   </widget>
+   <widget class="caChoice" name="cachoice_18">
+    <property name="geometry">
+     <rect>
+      <x>1030</x>
+      <y>445</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH7:IMonRange</string>
+    </property>
+    <property name="stackingMode" stdset="0">
+     <enum>caChoice::Column</enum>
+    </property>
+    <property name="endBit">
+     <number>1</number>
+    </property>
+   </widget>
+   <widget class="caChoice" name="cachoice_19">
+    <property name="geometry">
+     <rect>
+      <x>145</x>
+      <y>445</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH0:IMonRange</string>
+    </property>
+    <property name="stackingMode" stdset="0">
+     <enum>caChoice::Column</enum>
+    </property>
+    <property name="endBit">
+     <number>1</number>
+    </property>
+   </widget>
+   <widget class="caChoice" name="cachoice_20">
+    <property name="geometry">
+     <rect>
+      <x>780</x>
+      <y>445</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH5:IMonRange</string>
+    </property>
+    <property name="stackingMode" stdset="0">
+     <enum>caChoice::Column</enum>
+    </property>
+    <property name="endBit">
+     <number>1</number>
+    </property>
+   </widget>
+   <widget class="caChoice" name="cachoice_21">
+    <property name="geometry">
+     <rect>
+      <x>655</x>
+      <y>445</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH4:IMonRange</string>
+    </property>
+    <property name="stackingMode" stdset="0">
+     <enum>caChoice::Column</enum>
+    </property>
+    <property name="endBit">
+     <number>1</number>
+    </property>
+   </widget>
+   <widget class="caChoice" name="cachoice_22">
+    <property name="geometry">
+     <rect>
+      <x>530</x>
+      <y>445</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH3:IMonRange</string>
+    </property>
+    <property name="stackingMode" stdset="0">
+     <enum>caChoice::Column</enum>
+    </property>
+    <property name="endBit">
+     <number>1</number>
+    </property>
+   </widget>
+   <widget class="caChoice" name="cachoice_23">
+    <property name="geometry">
+     <rect>
+      <x>275</x>
+      <y>445</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH1:IMonRange</string>
+    </property>
+    <property name="stackingMode" stdset="0">
+     <enum>caChoice::Column</enum>
+    </property>
+    <property name="endBit">
+     <number>1</number>
+    </property>
+   </widget>
+   <widget class="caChoice" name="cachoice_24">
+    <property name="geometry">
+     <rect>
+      <x>405</x>
+      <y>445</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH2:IMonRange</string>
+    </property>
+    <property name="stackingMode" stdset="0">
+     <enum>caChoice::Column</enum>
+    </property>
+    <property name="endBit">
+     <number>1</number>
+    </property>
+   </widget>
+   <widget class="QLabel" name="label_14">
+    <property name="geometry">
+     <rect>
+      <x>15</x>
+      <y>445</y>
+      <width>121</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>IMon Range:</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+    </property>
+   </widget>
+   <widget class="caTextEntry" name="catextentry_12">
+    <property name="geometry">
+     <rect>
+      <x>145</x>
+      <y>110</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH0:Name</string>
+    </property>
+    <property name="background">
+     <color>
+      <red>115</red>
+      <green>223</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+   </widget>
+   <widget class="caTextEntry" name="catextentry_13">
+    <property name="geometry">
+     <rect>
+      <x>655</x>
+      <y>110</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH4:Name</string>
+    </property>
+    <property name="background">
+     <color>
+      <red>115</red>
+      <green>223</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+   </widget>
+   <widget class="caTextEntry" name="catextentry_14">
+    <property name="geometry">
+     <rect>
+      <x>1030</x>
+      <y>110</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH7:Name</string>
+    </property>
+    <property name="background">
+     <color>
+      <red>115</red>
+      <green>223</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+   </widget>
+   <widget class="caTextEntry" name="catextentry_15">
+    <property name="geometry">
+     <rect>
+      <x>905</x>
+      <y>110</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH6:Name</string>
+    </property>
+    <property name="background">
+     <color>
+      <red>115</red>
+      <green>223</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+   </widget>
+   <widget class="caTextEntry" name="catextentry_16">
+    <property name="geometry">
+     <rect>
+      <x>530</x>
+      <y>110</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH3:Name</string>
+    </property>
+    <property name="background">
+     <color>
+      <red>115</red>
+      <green>223</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+   </widget>
+   <widget class="caTextEntry" name="catextentry_17">
+    <property name="geometry">
+     <rect>
+      <x>405</x>
+      <y>110</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH2:Name</string>
+    </property>
+    <property name="background">
+     <color>
+      <red>115</red>
+      <green>223</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+   </widget>
+   <widget class="caTextEntry" name="catextentry_18">
+    <property name="geometry">
+     <rect>
+      <x>780</x>
+      <y>110</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH5:Name</string>
+    </property>
+    <property name="background">
+     <color>
+      <red>115</red>
+      <green>223</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+   </widget>
+   <widget class="caTextEntry" name="catextentry_19">
+    <property name="geometry">
+     <rect>
+      <x>275</x>
+      <y>110</y>
+      <width>100</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="channel" stdset="0">
+     <string notr="true">$(P)$(R)CH1:Name</string>
+    </property>
+    <property name="background">
+     <color>
+      <red>115</red>
+      <green>223</green>
+      <blue>255</blue>
+     </color>
+    </property>
+    <property name="colorMode">
+     <enum>caLineEdit::Static</enum>
+    </property>
+   </widget>
+   <zorder>caframe_8</zorder>
+   <zorder>caLineEdit_17</zorder>
+   <zorder>caLineEdit_15</zorder>
+   <zorder>caLineEdit_14</zorder>
+   <zorder>caLineEdit_16</zorder>
+   <zorder>catextentry_4</zorder>
+   <zorder>catextentry_5</zorder>
+   <zorder>catextentry_6</zorder>
+   <zorder>catextentry_7</zorder>
+   <zorder>caLabel_45</zorder>
+   <zorder>caLineEdit_18</zorder>
+   <zorder>catextentry_8</zorder>
+   <zorder>catextentry_9</zorder>
+   <zorder>catextentry_10</zorder>
+   <zorder>caLineEdit_19</zorder>
+   <zorder>caLineEdit_20</zorder>
+   <zorder>caLineEdit_21</zorder>
+   <zorder>catextentry_11</zorder>
+   <zorder>caLineEdit_22</zorder>
+   <zorder>caLineEdit_23</zorder>
+   <zorder>caLineEdit_24</zorder>
+   <zorder>caLineEdit_25</zorder>
+   <zorder>caLineEdit_26</zorder>
+   <zorder>caLineEdit_27</zorder>
+   <zorder>caLineEdit_28</zorder>
+   <zorder>caLineEdit_29</zorder>
+   <zorder>caMenu_3</zorder>
+   <zorder>caMessageButton_3</zorder>
+   <zorder>label_9</zorder>
+   <zorder>label_10</zorder>
+   <zorder>caLineEdit_30</zorder>
+   <zorder>caLineEdit_31</zorder>
+   <zorder>calabel</zorder>
+   <zorder>calabel_2</zorder>
+   <zorder>calabel_3</zorder>
+   <zorder>calabel_4</zorder>
+   <zorder>calabel_5</zorder>
+   <zorder>calabel_6</zorder>
+   <zorder>calabel_7</zorder>
+   <zorder>calabel_8</zorder>
+   <zorder>calabel_9</zorder>
+   <zorder>calabel_10</zorder>
+   <zorder>calabel_11</zorder>
+   <zorder>calabel_12</zorder>
+   <zorder>calabel_13</zorder>
+   <zorder>calabel_14</zorder>
+   <zorder>calabel_15</zorder>
+   <zorder>calabel_16</zorder>
+   <zorder>cachoice</zorder>
+   <zorder>cachoice_2</zorder>
+   <zorder>cachoice_3</zorder>
+   <zorder>cachoice_4</zorder>
+   <zorder>cachoice_5</zorder>
+   <zorder>cachoice_6</zorder>
+   <zorder>cachoice_7</zorder>
+   <zorder>cachoice_8</zorder>
+   <zorder>catextentry_27</zorder>
+   <zorder>catextentry_22</zorder>
+   <zorder>catextentry_25</zorder>
+   <zorder>catextentry_21</zorder>
+   <zorder>catextentry_24</zorder>
+   <zorder>catextentry_20</zorder>
+   <zorder>catextentry_23</zorder>
+   <zorder>catextentry_26</zorder>
+   <zorder>catextentry_28</zorder>
+   <zorder>catextentry_29</zorder>
+   <zorder>catextentry_30</zorder>
+   <zorder>catextentry_31</zorder>
+   <zorder>catextentry_32</zorder>
+   <zorder>catextentry_33</zorder>
+   <zorder>catextentry_34</zorder>
+   <zorder>catextentry_35</zorder>
+   <zorder>label_11</zorder>
+   <zorder>label_12</zorder>
+   <zorder>caLineEdit_32</zorder>
+   <zorder>caLineEdit_33</zorder>
+   <zorder>caLineEdit_34</zorder>
+   <zorder>caLineEdit_35</zorder>
+   <zorder>caLineEdit_36</zorder>
+   <zorder>caLineEdit_37</zorder>
+   <zorder>caLineEdit_38</zorder>
+   <zorder>caLineEdit_39</zorder>
+   <zorder>caLineEdit_40</zorder>
+   <zorder>caLineEdit_41</zorder>
+   <zorder>caLineEdit_42</zorder>
+   <zorder>caLineEdit_43</zorder>
+   <zorder>caLineEdit_44</zorder>
+   <zorder>caLineEdit_45</zorder>
+   <zorder>caLineEdit_46</zorder>
+   <zorder>caLineEdit_47</zorder>
+   <zorder>caLineEdit_48</zorder>
+   <zorder>caLineEdit_49</zorder>
+   <zorder>cachoice_9</zorder>
+   <zorder>cachoice_10</zorder>
+   <zorder>cachoice_11</zorder>
+   <zorder>cachoice_12</zorder>
+   <zorder>cachoice_13</zorder>
+   <zorder>cachoice_14</zorder>
+   <zorder>cachoice_15</zorder>
+   <zorder>cachoice_16</zorder>
+   <zorder>label_13</zorder>
+   <zorder>cachoice_17</zorder>
+   <zorder>cachoice_18</zorder>
+   <zorder>cachoice_19</zorder>
+   <zorder>cachoice_20</zorder>
+   <zorder>cachoice_21</zorder>
+   <zorder>cachoice_22</zorder>
+   <zorder>cachoice_23</zorder>
+   <zorder>cachoice_24</zorder>
+   <zorder>label_14</zorder>
+   <zorder>catextentry_12</zorder>
+   <zorder>catextentry_13</zorder>
+   <zorder>catextentry_14</zorder>
+   <zorder>catextentry_15</zorder>
+   <zorder>catextentry_16</zorder>
+   <zorder>catextentry_17</zorder>
+   <zorder>catextentry_18</zorder>
+   <zorder>catextentry_19</zorder>
+  </widget>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>caMenu</class>
+   <extends>QComboBox</extends>
+   <header>caMenu</header>
+  </customwidget>
+  <customwidget>
+   <class>caChoice</class>
+   <extends>QWidget</extends>
+   <header>caChoice</header>
+  </customwidget>
+  <customwidget>
+   <class>caTextEntry</class>
+   <extends>caLineEdit</extends>
+   <header>caTextEntry</header>
+  </customwidget>
+  <customwidget>
+   <class>caMessageButton</class>
+   <extends>QPushButton</extends>
+   <header>caMessageButton</header>
+  </customwidget>
+  <customwidget>
+   <class>caFrame</class>
+   <extends>QFrame</extends>
+   <header>caFrame</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>caLabel</class>
+   <extends>QLabel</extends>
+   <header>caLabel</header>
+  </customwidget>
+  <customwidget>
+   <class>caLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>caLineEdit</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
StreamDevice support for [CAEN N8031](https://www.caen.it/products/n8031/) 8 channel power supply.

Other CAEN 803x series power supplies supposedly use the same command set, though they may have a different number of channels (16 instead of 8). This support could be easily expanded in the future to work with the 16 channel models as well.